### PR TITLE
Fix text of annual income options on Lookit demographic form

### DIFF
--- a/app/controllers/my/demographics.js
+++ b/app/controllers/my/demographics.js
@@ -75,11 +75,11 @@ export default Ember.Controller.extend({
         'not applicable - no spouse or partner'
     ],
     annualIncomeOptions: Ember.computed(function() {
-        var ret = ['0', '$5000', '$1000', '$15000'];
+        var ret = ['0', '5000', '10000', '15000'];
         for (var i = 20; i < 200; i += 10) {
             ret.push(`${i * 1000}`);
         }
-        ret.push('over $200000');
+        ret.push('over 200000');
         ret.push('prefer not to answer');
 
         return ret;

--- a/app/templates/my/demographics.hbs
+++ b/app/templates/my/demographics.hbs
@@ -115,7 +115,7 @@
         </select>
       {{/bs-form-group}}
       {{#bs-form-group}}
-        <label>What is your approximate family yearly income?</label>
+        <label>What is your approximate family yearly income (in US dollars)?</label>
         <select onchange={{action (mut account.demographicsAnnualIncome) value="target.value"}} class="form-control" >
           <option value="" disabled selected hidden>Please Choose...</option>
           {{#each annualIncomeOptions as |annualIncomeOption|}}


### PR DESCRIPTION
Shouldn't affect anything but Lookit demographics form, just fixing options (currently $5K, $1K, $15K, 20K, ...; fixed to 5K, 10K, 15K, 20K, ...)