### PR TITLE
Add "sound level" bar to recorder and document hidden config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ OSF_CLIENT_ID=<application_client_id>
 OSF_SCOPE=osf.users.all_read
 OSF_URL=https://staging-accounts.osf.io
 
-WOWZA_PHP='{"minRecordTime":1,"showMenu":"false","showTimer":"false","enableBlinkingRec":1,"skipInitialScreen":1,"recordAgain":"false","showSoundBar":"true","hideDeviceSettingsButtons":1,"connectionstring":"CONNECTIONSTRING"}'
-WOWZA_ASP='{"showMenu":"false","loopbackMic":"true","skipInitialScreen":1,"showSoundBar":"false","snapshotEnable":"false"}'
+WOWZA_PHP='{"minRecordTime":1,"showMenu":"false","showTimer":"false","enableBlinkingRec":1,"skipInitialScreen":1,"recordAgain":"false","showSoundBar":"true","hideDeviceSettingsButtons":1,"microphoneGain": 60,"connectionstring":"CONNECTIONSTRING"}'
+WOWZA_ASP='{"showMenu":"false","loopbackMic":"true","skipInitialScreen":1,"showSoundBar":"true","snapshotEnable":"false"}'
 
 JAMDB_URL=https://staging-metadata.osf.io
 JAMDB_NAMESPACE=experimenter
@@ -57,7 +57,7 @@ SENTRY_DSN=""
 ```
 
 A more complete configuration string is available upon request. In this application, we typically use `WOWZA_PHP` 
-for settings in which a video is actually recorded, and `WOWZA_ASP` for video preview screens.
+for settings in which a video is actually recorded, and `WOWZA_ASP` for video preview screens where no video is to be saved.
 The value of `connectionstring` is available internally but not committed to Github; **it must be replaced 
 with a reference to the streaming server.**  Other settings are as described in the sample `avc_settings.php` file 
 provided in the HDFVR installation zip file.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ bower install
 ```
 
 To use the video capture facilities of Lookit, you will also need to place the file `VideoRecorder.swf` 
-in your `lookit/public/` folder. This file is not part of the git repository; it is from the HDFVR flash video 
+in your `lookit/public/` folder. **This file is not part of the git repository**; it is from the HDFVR flash video 
 recorder and must be obtained from a team member with access to the licensed version.
 
 ## Running / Development
@@ -47,14 +47,21 @@ OSF_CLIENT_ID=<application_client_id>
 OSF_SCOPE=osf.users.all_read
 OSF_URL=https://staging-accounts.osf.io
 
-WOWZA_PHP='{}'
-WOWZA_ASP='{}'
+WOWZA_PHP='{"minRecordTime":1,"showMenu":"false","showTimer":"false","enableBlinkingRec":1,"skipInitialScreen":1,"recordAgain":"false","showSoundBar":"true","hideDeviceSettingsButtons":1,"connectionstring":"CONNECTIONSTRING"}'
+WOWZA_ASP='{"showMenu":"false","loopbackMic":"true","skipInitialScreen":1,"showSoundBar":"false","snapshotEnable":"false"}'
 
 JAMDB_URL=https://staging-metadata.osf.io
 JAMDB_NAMESPACE=experimenter
 
 SENTRY_DSN=""
 ```
+
+A more complete configuration string is available upon request. In this application, we typically use `WOWZA_PHP` 
+for settings in which a video is actually recorded, and `WOWZA_ASP` for video preview screens.
+The value of `connectionstring` is available internally but not committed to Github; **it must be replaced 
+with a reference to the streaming server.**  Other settings are as described in the sample `avc_settings.php` file 
+provided in the HDFVR installation zip file.
+
 3. Run the server with:
 ```bash
 ember server --environment staging

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ npm install
 bower install
 ```
 
+To use the video capture facilities of Lookit, you will also need to place the file `VideoRecorder.swf` 
+in your `lookit/public/` folder. This file is not part of the git repository; it is from the HDFVR flash video 
+recorder and must be obtained from a team member with access to the licensed version.
+
 ## Running / Development
 
 #### Configuration


### PR DESCRIPTION
# Companion to
TBD

# Purpose
1. Make it easier for the user to know when they have bad audio quality during the consent phase: show a sound bar (which will flash red if microphone is off) and increase gain slightly from 50 to 60.
2. Improve documentation of "hidden" configuration (files that must be copied over, and the subset of `.env` file settings that are not confidential)
3. Add user-facing instructions (on the setup page) to ensure that user knows if they have bad sound.

# Deployment
This will require changing the configuration `.env` file to match the samples provided in README.md. Specifically, `"showSoundBar": "true"` and `"microphoneGain": 60`.

# Notes
## Sound bar
The expected sound check bar is shown here:
<img width="90" alt="screen shot 2016-09-23 at 4 16 53 pm" src="https://cloud.githubusercontent.com/assets/2957073/18800121/4fa85284-81a9-11e6-84ab-6f99d1e969b6.png">

https://hdfvr.com/blog/hdfvr-2/

## Other design options
- We would like to be able to play back a given video. However, the video may not be immediately in the ec2 <destionation_folder> directory for up to several minutes after being submitted. Will explore further.