### PR TITLE
Ensure username displays correctly for new users

### DIFF
--- a/app/authenticators/jam-jwt.js
+++ b/app/authenticators/jam-jwt.js
@@ -39,7 +39,7 @@ export default BaseAuthenticator.extend({
                 });
             });
         }
-        return $.ajax({
+        let jqDeferred = $.ajax({
             method: 'POST',
             url: this.url,
             dataType: 'json',
@@ -54,6 +54,11 @@ export default BaseAuthenticator.extend({
             // Include logged-in user data with all Raven payloads during session
             this._captureUser(res.id);
             return res.data.attributes;
+        });
+
+        return new Ember.RSVP.Promise((resolve, reject) => {
+            jqDeferred.done(resolve);
+            jqDeferred.fail(reject);
         });
     },
 

--- a/app/components/jam-create.js
+++ b/app/components/jam-create.js
@@ -9,11 +9,7 @@ export default Ember.Component.extend({
     password: null,
     email: null,
 
-    maySubmit: Ember.computed('username', 'password', 'email', function () {
-        return ['username', 'password', 'email']
-            .map(k => this.get(k))
-            .reduce((acc, val) => acc && val);
-    }),
+    maySubmit: Ember.computed.and('username', 'password', 'email'),
 
     actions: {
         createAccount() {
@@ -21,7 +17,6 @@ export default Ember.Component.extend({
                 username: this.get('username'),
                 password: this.get('password'),
                 email: this.get('email')
-                // Add fields for permissions and history?
             });
             return false;
         }

--- a/app/components/jam-create.js
+++ b/app/components/jam-create.js
@@ -2,28 +2,28 @@ import Ember from 'ember';
 import ENV from 'lookit-base/config/environment';
 
 export default Ember.Component.extend({
-  namespace: ENV.JAMDB.namespace,
-  collection: ENV.JAMDB.collection,
+    namespace: ENV.JAMDB.namespace,
+    collection: ENV.JAMDB.collection,
 
-  username: null,
-  password: null,
+    username: null,
+    password: null,
     email: null,
 
-  maySubmit: function() {
-      return ['username', 'password', 'email']
-          .map(k => this.get(k))
-          .reduce((acc, val) => acc && val);
-  }.property('username', 'password', 'email'),
+    maySubmit: Ember.computed('username', 'password', 'email', function () {
+        return ['username', 'password', 'email']
+            .map(k => this.get(k))
+            .reduce((acc, val) => acc && val);
+    }),
 
-  actions: {
-    createAccount() {
-      this.get('create')({
-        username: this.get('username'),
-        password: this.get('password'),
-          email: this.get('email')
-//        Add fields for permissions and history?
-      });
-      return false;
+    actions: {
+        createAccount() {
+            this.get('create')({
+                username: this.get('username'),
+                password: this.get('password'),
+                email: this.get('email')
+                // Add fields for permissions and history?
+            });
+            return false;
+        }
     }
-  }
 });

--- a/app/components/study-feedback-text.js
+++ b/app/components/study-feedback-text.js
@@ -12,14 +12,14 @@ export default Ember.Component.extend({
     profileName: null,
 
     init() {
-	this._super(...arguments);
-	this.get('session').getProfile().then((profile) => {
-	    this.set('profileName', profile.get('firstName'));
-	});
+        this._super(...arguments);
+        this.get('session').getProfile().then((profile) => {
+            this.set('profileName', profile.get('firstName'));
+        });
     },
 
     actions: {
-        toggleFeedback: function() {
+        toggleFeedback: function () {
             this.toggleProperty('showFeedback');
             if (this.get('showFeedback')) {
                 this.set('feedbackText', 'Hide Feedback');

--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -40,35 +40,40 @@ export default Ember.Controller.extend({
             });
             newAccount.save().then(() => {
                 // log in immediately with this new account information
-                var theAttrs = {provider: 'self', namespace: config.JAMDB.namespace, collection: 'accounts', username: attrs.username, password: attrs.password};
+                var theAttrs = {
+                    provider: 'self',
+                    namespace: config.JAMDB.namespace,
+                    collection: 'accounts',
+                    username: attrs.username,
+                    password: attrs.password
+                };
                 this.send('authenticate', theAttrs);
-            }, (res) => {
+            }).catch((res) => {
                 this.set('creatingUser', false);
-                if(res.errors[0].status === '409') {
+                if (res.errors[0].status === '409') {
                     this.send('toggleUserConflict');
-                }
-                else {
+                } else {
                     this.send('toggleInvalidAuth');
                 }
             });
         },
-	resetPassword() {
-	    let options = Ember.getOwner(this).lookup('adapter:application').ajaxOptions();
-	    Ember.$.ajaxSetup(options);
-	    let url = `${config.JAMDB.url}/v1/id/collections/${config.JAMDB.namespace}.accounts/user`;
-	    Ember.$.ajax({
-		url: url,
-		method: 'POST',
-		data: JSON.stringify({
-		    data: {
-			type: "reset",
-			attributes: {
-			    id: this.get('resetId')
-			}
-		    }
-		})
-	    }).then(() => this.set('resetSent', true));
-	},
+        resetPassword() {
+            let options = Ember.getOwner(this).lookup('adapter:application').ajaxOptions();
+            Ember.$.ajaxSetup(options);
+            let url = `${config.JAMDB.url}/v1/id/collections/${config.JAMDB.namespace}.accounts/user`;
+            Ember.$.ajax({
+                url: url,
+                method: 'POST',
+                data: JSON.stringify({
+                    data: {
+                        type: "reset",
+                        attributes: {
+                            id: this.get('resetId')
+                        }
+                    }
+                })
+            }).then(() => this.set('resetSent', true));
+        },
         toggleUserConflict() {
             this.toggleProperty('userConflict');
         },

--- a/app/controllers/my.js
+++ b/app/controllers/my.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-
 });

--- a/app/controllers/my/children.js
+++ b/app/controllers/my/children.js
@@ -12,27 +12,27 @@ export default Ember.Controller.extend({
     addingNew: false,
     notAddingNew: Ember.computed.not('addingNew'),
     childProfile: null,
-    newProfile: function() {
+    newProfile: function () {
         this.set('childProfile', this.get('store').createRecord('profile', {
             deleted: false
         }));
     },
     init() {
-	this.newProfile();
+        this.newProfile();
     },
-    onModelChange: Ember.observer('account', function() {
+    onModelChange: Ember.observer('account', function () {
         this.newProfile();
     }),
     actions: {
         profileAdded () {
-	    this.newProfile();
+            this.newProfile();
             this.toggleProperty('addingNew');
         },
         toggleAddingNew () {
             this.toggleProperty('addingNew');
         },
         cancelAddProfile () {
-	    this.newProfile();
+            this.newProfile();
             this.toggleProperty('addingNew');
         }
     }

--- a/app/controllers/my/email.js
+++ b/app/controllers/my/email.js
@@ -6,22 +6,22 @@ export default Ember.Controller.extend({
     account: Ember.computed.alias('sessionAccount.account'),
     suppressions: null,
     _setSuppressions() {
-	if (this.get('account')) {
-	    this.get('account').getSuppressions().then(suppressions => {
-		this.set('suppressions', suppressions);
-	    });
-	}
+        if (this.get('account')) {
+            this.get('account').getSuppressions().then(suppressions => {
+                this.set('suppressions', suppressions);
+            });
+        }
     },
     init() {
-	this._super(...arguments);
-	this._setSuppressions();
+        this._super(...arguments);
+        this._setSuppressions();
     },
-    onAccountChange: Ember.observer('account', function() {
-	this._setSuppressions();
+    onAccountChange: Ember.observer('account', function () {
+        this._setSuppressions();
     }),
     canSave: true,
     actions: {
-        saveEmailPreferences: function() {
+        saveEmailPreferences: function () {
             var suppressions = this.get('suppressions');
             this.set('canSave', false);
             this.get('sessionAccount').loadCurrentUser().then(account => {

--- a/app/controllers/my/index.js
+++ b/app/controllers/my/index.js
@@ -1,7 +1,7 @@
 /* global dcodeIO */
 import Ember from 'ember';
 
-const {bcrypt} = dcodeIO;
+const { bcrypt } = dcodeIO;
 
 export default Ember.Controller.extend({
     _error: null,
@@ -11,10 +11,10 @@ export default Ember.Controller.extend({
     account: Ember.computed.alias('sessionAccount.account'),
     toast: Ember.inject.service(),
 
-    passMatch: function() {
+    passMatch: Ember.computed('newPass', 'confirmPass', function() {
         this.set('_error');
         return this.get('newPass') === this.get('confirmPass');
-    }.property('newPass', 'confirmPass'),
+    }),
 
     canUpdate: Ember.computed.and('newPass', 'confirmPass', 'passMatch'),
 

--- a/app/controllers/participate.js
+++ b/app/controllers/participate.js
@@ -1,11 +1,9 @@
 import Ember from 'ember';
 
-const { service } = Ember.inject;
-
 export default Ember.Controller.extend({
     model: null,
     session: null,
-    sessionAccount: service('session-account'),
+    sessionAccount: Ember.inject.service('session-account'),
     store: Ember.inject.service(),
     isDirty: function() {
         // TODO: check the session model to see if it contains unsaved data

--- a/app/controllers/studies/detail.js
+++ b/app/controllers/studies/detail.js
@@ -5,24 +5,23 @@ export default Ember.Controller.extend({
     sessionAccount: Ember.inject.service(),
     account: Ember.computed.alias('sessionAccount.account'),
     selectedChildId: null,
-    selectedChild: Ember.computed('selectedChildId', function() {
+    selectedChild: Ember.computed('selectedChildId', function () {
         let account = this.get('sessionAccount').get('account');
         return account.profileById(this.get('selectedChildId'));
     }),
 
-    isAgeEligible: Ember.computed('selectedChild', function() {
+    isAgeEligible: Ember.computed('selectedChild', function () {
         let child = this.get('selectedChild');
         if (!child) {
             return true;
         }
         let experiment = this.get('model');
-	return experiment.isEligible(child);
+        return experiment.isEligible(child);
     }),
 
-    route: function() {
+    route: Ember.computed('model', function () {
         return `${Ember.getOwner(this).lookup('router:main').get('currentPath')}:${this.get('model.id')}`;
-    }.property('model'),
-    
+    }),
     actions: {
         pickChild() {
             let profile = this.get('selectedChild');

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -5,7 +5,8 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
     session: Ember.inject.service('session'),
     sessionAccount: Ember.inject.service('session-account'),
     sessionAuthenticated() {
-        this._super(...arguments);
-        this.get('sessionAccount').loadCurrentUser().catch(() => this.get('session').invalidate());
+        this.get('sessionAccount').loadCurrentUser()
+            .then(() => this._super(...arguments))
+            .catch(() => this.get('session').invalidate());
     }
 });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,13 +1,9 @@
 import Ember from 'ember';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 
-const {
-    service
-} = Ember.inject;
-
 export default Ember.Route.extend(ApplicationRouteMixin, {
-    session: service('session'),
-    sessionAccount: service('session-account'),
+    session: Ember.inject.service('session'),
+    sessionAccount: Ember.inject.service('session-account'),
     sessionAuthenticated() {
         this._super(...arguments);
         this.get('sessionAccount').loadCurrentUser().catch(() => this.get('session').invalidate());

--- a/app/routes/my.js
+++ b/app/routes/my.js
@@ -1,13 +1,9 @@
 import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-const {
-    service
-} = Ember.inject;
-
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
-    session: service('session'),
-    sessionAccount: service('session-account'),
+    session: Ember.inject.service('session'),
+    sessionAccount: Ember.inject.service('session-account'),
 
     model() {
         return this.get('sessionAccount').loadCurrentUser();

--- a/app/routes/my.js
+++ b/app/routes/my.js
@@ -18,9 +18,9 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
                 .authenticate('authenticator:jam-jwt', {}, transition.queryParams.access_token)
                 .then(() => {
                     window.location.hash = '';
-		    return this._super(...arguments);
+                    return this._super(...arguments);
                 });
         }
-	return this._super(...arguments);
+        return this._super(...arguments);
     }
 });

--- a/app/routes/participate.js
+++ b/app/routes/participate.js
@@ -1,16 +1,14 @@
 import Ember from 'ember';
-// Do we want/need this?
+
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 import ExpPlayerRouteMixin from 'exp-player/mixins/exp-player-route';
 import WarnOnExitRouteMixin from 'exp-player/mixins/warn-on-exit-route';
 
-const { service } = Ember.inject;
-
 export default Ember.Route.extend(AuthenticatedRouteMixin, ExpPlayerRouteMixin, WarnOnExitRouteMixin, {
     raven: Ember.inject.service('raven'),
 
-    sessionAccount: service('session-account'),
+    sessionAccount: Ember.inject.service('session-account'),
 
     _getExperiment(params) {
         return this.store.findRecord('experiment', Ember.get(params, 'experiment_id'));

--- a/app/routes/studies.js
+++ b/app/routes/studies.js
@@ -1,9 +1,7 @@
 import Ember from 'ember';
 
-
 export default Ember.Route.extend({
     model() {
-        // This network request seems to grab the right data using elasticSearch syntax...
         let Experiment = this.store.modelFor('experiment');
         return this.store.query('experiment', {
             q:`state:${Experiment.prototype.ACTIVE}`

--- a/app/routes/studies/history.js
+++ b/app/routes/studies/history.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
 
     model( /*params*/ ) {

--- a/app/services/session-account.js
+++ b/app/services/session-account.js
@@ -1,19 +1,11 @@
 import Ember from 'ember';
 
-const {
-    inject: {
-        service
-    },
-    RSVP
-} = Ember;
-
-
 export default Ember.Service.extend({
     account: null,
     profile: null,
 
-    session: service('session'),
-    store: service(),
+    session: Ember.inject.service('session'),
+    store: Ember.inject.service(),
 
     _setAccount() {
         const accountId = this.get('session.data.authenticated.id');
@@ -38,7 +30,7 @@ export default Ember.Service.extend({
     },
 
     loadCurrentUser() {
-        return new RSVP.Promise((resolve) => {
+        return new Ember.RSVP.Promise((resolve) => {
             if (!this.get('session.isAuthenticated')) {
                 return resolve(null);
             }

--- a/app/templates/my/index.hbs
+++ b/app/templates/my/index.hbs
@@ -4,7 +4,7 @@
   <div class="form-group">
     <label class="col-sm-2 control-label">Username</label>
     <div class="col-sm-10">
-      <p class="form-control"> {{account.username}} </p>
+      <input class="form-control" value="{{account.username}}" disabled>
     </div>
   </div>
   <div class="form-group">

--- a/app/utils/validators.js
+++ b/app/utils/validators.js
@@ -2,22 +2,22 @@ import Ember from 'ember';
 
 export default {
     min (lower) {
-	return (value) => {
-	    return value >= lower;
-	};
+        return (value) => {
+            return value >= lower;
+        };
     },
     max (upper) {
-	return (value) => {
-	    return value <= upper;
-	};
-    },    
+        return (value) => {
+            return value <= upper;
+        };
+    },
     join (...validators) {
-	return (value) => {
-	    Ember.computed.and(
-		validators.map((validator) => {
-		    return validator(value);
-		})
-	    );		
-	};
+        return (value) => {
+            Ember.computed.and(
+                validators.map((validator) => {
+                    return validator(value);
+                })
+            );
+        };
     }
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,6 @@ require('dotenv').config();
 var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
-
     var app = new EmberApp(defaults, {
         sourcemaps: {
             enabled: true

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-radio-buttons": "4.0.1",
     "ember-resolver": "^2.0.3",
     "ember-scroll-to": "0.5.1",
-    "ember-simple-auth": "1.0.1",
+    "ember-simple-auth": "1.1.0",
     "ember-toastr": "1.4.0",
     "ember-truth-helpers": "1.2.0",
     "eonasdan-bootstrap-datetimepicker": "4.15.35",


### PR DESCRIPTION
# Ticket
https://openscience.atlassian.net/browse/LEI-219

Depends on: 
https://github.com/CenterForOpenScience/exp-addons/issues/156

# Purpose
Migrated users should be taken to the accounts page, so that they can identify their new username / account details.

# Summary of changes
Testing this PR revealed a separate issue: a race condition that prevented the user from being sent to the accounts page on first use of an access_token. (failed in Chrome, worked in Firefox) In Chrome, they were being taken to the homepage instead.

- Update version of ember-simple-auth to avoid deprecation warnings
- Reformat code
- Fix race condition
- Make sure that migrated users have a username that can be accessed by the page