### PR TITLE
Successful login should take the user away from login page

### DIFF
--- a/app/authenticators/jam-jwt.js
+++ b/app/authenticators/jam-jwt.js
@@ -13,7 +13,7 @@ const {
 export default BaseAuthenticator.extend({
     url: `${ENV.JAMDB.url}/v1/auth`,
 
-    raven: Ember.inject.service('raven'),
+    raven: Ember.inject.service(),
 
     _captureUser(username) {
         this.get('raven').callRaven('setUserContext', { id: username });

--- a/app/authenticators/jam-jwt.js
+++ b/app/authenticators/jam-jwt.js
@@ -52,7 +52,7 @@ export default BaseAuthenticator.extend({
                 } catch (e) {
                     reject();
                 }
-                if (!this._verifyToken(token)) {
+                if (!this._verifyToken(payload)) {
                     reject();
                 }
 

--- a/app/authenticators/jam-jwt.js
+++ b/app/authenticators/jam-jwt.js
@@ -33,6 +33,7 @@ export default BaseAuthenticator.extend({
             var payload = jwt_decode(token);
             var accountId = payload.sub.split('-').pop();
             return new Ember.RSVP.Promise(resolve => {
+                this._captureUser(accountId);
                 resolve({
                     id: accountId,
                     token: token

--- a/app/components/main-nav.js
+++ b/app/components/main-nav.js
@@ -3,6 +3,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
     session: Ember.inject.service('session'),
     sessionAccount: Ember.inject.service('session-account'),
+    // TODO: Check the meaning of the name field. Is it still being used at all?
     accountName: Ember.computed.or('sessionAccount.account.name', 'sessionAccount.account.username'),
     actions: {
         logout() {

--- a/app/components/main-nav.js
+++ b/app/components/main-nav.js
@@ -9,20 +9,17 @@ export default Ember.Component.extend({
      */
     logout: null,
 
-    // TODO: Check the meaning of the name field. Is it still being used at all?
     // Placeholder: account will be set when session auth state changes
     account: null,
     accountName: Ember.computed.alias('account.username'),
 
     updateAccount: Ember.observer('session.isAuthenticated', function () {
-        let foundUser;
         if (!this.get('session.isAuthenticated')) {
-            foundUser = null;
+            this.set('account', null);
         } else {
-            this.get('sessionAccount')
-                .load().then(account => {foundUser = account;})
-                .catch(() => {foundUser = null;});
+            this.get('sessionAccount').load()
+                .then(account => this.set('account', account))
+                .catch(() => this.set('account', null));
         }
-        this.set('account', foundUser);
     })
 });

--- a/app/components/main-nav.js
+++ b/app/components/main-nav.js
@@ -1,13 +1,28 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-    session: Ember.inject.service('session'),
-    sessionAccount: Ember.inject.service('session-account'),
+    session: Ember.inject.service(),
+    sessionAccount: Ember.inject.service(),
+
+    /**
+     * @method logout A passed in closure action
+     */
+    logout: null,
+
     // TODO: Check the meaning of the name field. Is it still being used at all?
-    accountName: Ember.computed.or('sessionAccount.account.name', 'sessionAccount.account.username'),
-    actions: {
-        logout() {
-            Ember.getOwner(this).lookup('controller:application').send('logout');
+    // Placeholder: account will be set when session auth state changes
+    account: null,
+    accountName: Ember.computed.alias('account.username'),
+
+    updateAccount: Ember.observer('session.isAuthenticated', function () {
+        let foundUser;
+        if (!this.get('session.isAuthenticated')) {
+            foundUser = null;
+        } else {
+            this.get('sessionAccount')
+                .load().then(account => {foundUser = account;})
+                .catch(() => {foundUser = null;});
         }
-    }
+        this.set('account', foundUser);
+    })
 });

--- a/app/components/main-nav.js
+++ b/app/components/main-nav.js
@@ -13,7 +13,12 @@ export default Ember.Component.extend({
     account: null,
     accountName: Ember.computed.alias('account.username'),
 
-    updateAccount: Ember.observer('session.isAuthenticated', function () {
+    init() {
+        this._super(...arguments);
+        this._fetchAccount();
+    },
+
+    _fetchAccount() {
         if (!this.get('session.isAuthenticated')) {
             this.set('account', null);
         } else {
@@ -21,5 +26,9 @@ export default Ember.Component.extend({
                 .then(account => this.set('account', account))
                 .catch(() => this.set('account', null));
         }
+    },
+
+    updateAccount: Ember.observer('session.isAuthenticated', function () {
+        this._fetchAccount();
     })
 });

--- a/app/components/study-header.js
+++ b/app/components/study-header.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-    session: Ember.inject.service('session')
+    session: Ember.inject.service()
 });

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -4,7 +4,6 @@ const { service } = Ember.inject;
 
 export default Ember.Controller.extend({
     session: service('session'),
-    sessionAccount: service('session-account'),
     isParticipate: Ember.computed('currentPath', function() {
         return this.get('currentPath') === 'participate';
     }),

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,9 +1,8 @@
 import Ember from 'ember';
 
-const { service } = Ember.inject;
-
 export default Ember.Controller.extend({
-    session: service('session'),
+    session: Ember.inject.service(),
+
     isParticipate: Ember.computed('currentPath', function() {
         return this.get('currentPath') === 'participate';
     }),

--- a/app/controllers/home.js
+++ b/app/controllers/home.js
@@ -1,7 +1,5 @@
 import Ember from 'ember';
 
-const { service } = Ember.inject;
-
 export default Ember.Controller.extend({
-    session: service('session'),
+    session: Ember.inject.service(),
 });

--- a/app/controllers/home.js
+++ b/app/controllers/home.js
@@ -4,5 +4,4 @@ const { service } = Ember.inject;
 
 export default Ember.Controller.extend({
     session: service('session'),
-    sessionAccount: service('session-account')
 });

--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -3,9 +3,9 @@ import Ember from 'ember';
 import config from 'ember-get-config';
 
 export default Ember.Controller.extend({
-    modal: false,
+    session: Ember.inject.service(),
+
     queryParams: ['ref'],
-    session: Ember.inject.service('session'),
 
     isIE: /(MSIE|rv:11.0)/i.test(navigator.userAgent),
 

--- a/app/controllers/my/children.js
+++ b/app/controllers/my/children.js
@@ -1,13 +1,10 @@
 import Ember from 'ember';
 
-const { service } = Ember.inject;
-
 export default Ember.Controller.extend({
-    session: service('session'),
-    sessionAccount: service('session-account'),
+    session: Ember.inject.service(),
 
-    store: service(),
-    toast: service(),
+    store: Ember.inject.service(),
+    toast: Ember.inject.service(),
 
     addingNew: false,
     notAddingNew: Ember.computed.not('addingNew'),

--- a/app/controllers/my/children.js
+++ b/app/controllers/my/children.js
@@ -5,7 +5,7 @@ const { service } = Ember.inject;
 export default Ember.Controller.extend({
     session: service('session'),
     sessionAccount: service('session-account'),
-    account: Ember.computed.alias('sessionAccount.account'),
+
     store: service(),
     toast: service(),
 
@@ -20,7 +20,7 @@ export default Ember.Controller.extend({
     init() {
         this.newProfile();
     },
-    onModelChange: Ember.observer('account', function () {
+    onModelChange: Ember.observer('model', function () {
         this.newProfile();
     }),
     actions: {

--- a/app/controllers/my/demographics.js
+++ b/app/controllers/my/demographics.js
@@ -8,7 +8,6 @@ import validators from 'lookit-base/utils/validators';
 
 export default Ember.Controller.extend({
     session: service('session'),
-    sessionAccount: service('session-account'),
 
     selectedRaceIdentification: Ember.computed.alias('model.demographicsRaceIdentification'),
     today: new Date(),

--- a/app/controllers/my/demographics.js
+++ b/app/controllers/my/demographics.js
@@ -1,13 +1,9 @@
 import Ember from 'ember';
 
-const {
-    service
-} = Ember.inject;
-
 import validators from 'lookit-base/utils/validators';
 
 export default Ember.Controller.extend({
-    session: service('session'),
+    session: Ember.inject.service(),
 
     selectedRaceIdentification: Ember.computed.alias('model.demographicsRaceIdentification'),
     today: new Date(),

--- a/app/controllers/my/demographics.js
+++ b/app/controllers/my/demographics.js
@@ -9,8 +9,8 @@ import validators from 'lookit-base/utils/validators';
 export default Ember.Controller.extend({
     session: service('session'),
     sessionAccount: service('session-account'),
-    account: Ember.computed.alias('sessionAccount.account'),
-    selectedRaceIdentification: Ember.computed.alias('account.demographicsRaceIdentification'),
+
+    selectedRaceIdentification: Ember.computed.alias('model.demographicsRaceIdentification'),
     today: new Date(),
     ageChoices: [
         'under 18',
@@ -96,13 +96,13 @@ export default Ember.Controller.extend({
         'no'
     ],
 
-    isValid: Ember.computed('account.demographicsNumberOfBooks', function() {
-        return validators.min(0)(this.get('account.demographicsNumberOfBooks'));
+    isValid: Ember.computed('model.demographicsNumberOfBooks', function() {
+        return validators.min(0)(this.get('model.demographicsNumberOfBooks'));
     }),
 
     nNumberOfChildren: 11,
-    numberOfChildren: Ember.computed('nNumberOfChildren', 'account.demographicsNumberOfChildren', function() {
-        var numberOfChildren = this.get('account.demographicsNumberOfChildren');
+    numberOfChildren: Ember.computed('nNumberOfChildren', 'model.demographicsNumberOfChildren', function() {
+        var numberOfChildren = this.get('model.demographicsNumberOfChildren');
         if (!numberOfChildren) {
             return 0;
         } else if (isNaN(numberOfChildren)) {
@@ -120,14 +120,14 @@ export default Ember.Controller.extend({
         var numberOfChildren = this.get('numberOfChildren');
         var birthdays = [];
         for (var i = 0; i < numberOfChildren; i++) {
-            birthdays[i] = this.get('account.demographicsChildBirthdays').objectAt(i);
+            birthdays[i] = this.get('model.demographicsChildBirthdays').objectAt(i);
         }
-        this.get('account.demographicsChildBirthdays').setObjects(birthdays);
+        this.get('model.demographicsChildBirthdays').setObjects(birthdays);
     }),
-    childBirthdays: Ember.computed('account.demographicsChildBirthdays.[]', {
+    childBirthdays: Ember.computed('model.demographicsChildBirthdays.[]', {
         get: function() {
             var ret = Ember.Object.create();
-            this.get('account.demographicsChildBirthdays').toArray().forEach(function(bd, i) {
+            this.get('model.demographicsChildBirthdays').toArray().forEach(function(bd, i) {
                 ret.set(i.toString(), bd);
             });
             return ret;
@@ -137,7 +137,7 @@ export default Ember.Controller.extend({
             Object.keys(birthdays).forEach(function(key) {
                 ret[parseInt(key)] = birthdays[key];
             });
-            this.get('account.demographicsChildBirthdays').setObjects(ret);
+            this.get('model.demographicsChildBirthdays').setObjects(ret);
             this.propertyDidChange('childBirthdays');
             return this.get('childBirthdays');
         }
@@ -155,7 +155,7 @@ export default Ember.Controller.extend({
             this.set('selectedRaceIdentification', selectedRaceIdentification);
         },
         saveDemographicsPreferences: function() {
-            this.get('account').save().then(() => {
+            this.get('model').save().then(() => {
                 this.toast.info('Demographic survey saved successfully.');
             });
         },

--- a/app/controllers/my/email.js
+++ b/app/controllers/my/email.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
     toast: Ember.inject.service(),
-    sessionAccount: Ember.inject.service('session-account'),
 
     suppressions: null,
     _setSuppressions() {

--- a/app/controllers/my/email.js
+++ b/app/controllers/my/email.js
@@ -3,11 +3,11 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
     toast: Ember.inject.service(),
     sessionAccount: Ember.inject.service('session-account'),
-    account: Ember.computed.alias('sessionAccount.account'),
+
     suppressions: null,
     _setSuppressions() {
-        if (this.get('account')) {
-            this.get('account').getSuppressions().then(suppressions => {
+        if (this.get('model')) {
+            this.get('model').getSuppressions().then(suppressions => {
                 this.set('suppressions', suppressions);
             });
         }
@@ -16,7 +16,7 @@ export default Ember.Controller.extend({
         this._super(...arguments);
         this._setSuppressions();
     },
-    onAccountChange: Ember.observer('account', function () {
+    onAccountChange: Ember.observer('model', function () {
         this._setSuppressions();
     }),
     canSave: true,
@@ -24,7 +24,7 @@ export default Ember.Controller.extend({
         saveEmailPreferences: function () {
             var suppressions = this.get('suppressions');
             this.set('canSave', false);
-            let account = this.get('sessionAccount.account');
+            let account = this.get('model');
             var suppressionsHash = {};
             Object.keys(suppressions).forEach(s => {
                 var suppression = suppressions[s];

--- a/app/controllers/my/email.js
+++ b/app/controllers/my/email.js
@@ -24,7 +24,7 @@ export default Ember.Controller.extend({
         saveEmailPreferences: function () {
             var suppressions = this.get('suppressions');
             this.set('canSave', false);
-            this.get('sessionAccount').loadCurrentUser().then(account => {
+            this.get('sessionAccount').load().then(account => {
                 var suppressionsHash = {};
                 Object.keys(suppressions).forEach(s => {
                     var suppression = suppressions[s];

--- a/app/controllers/my/email.js
+++ b/app/controllers/my/email.js
@@ -24,16 +24,15 @@ export default Ember.Controller.extend({
         saveEmailPreferences: function () {
             var suppressions = this.get('suppressions');
             this.set('canSave', false);
-            this.get('sessionAccount').load().then(account => {
-                var suppressionsHash = {};
-                Object.keys(suppressions).forEach(s => {
-                    var suppression = suppressions[s];
-                    suppressionsHash[`${suppression.id}`] = !suppression.subscribed;
-                });
-                account.setSuppressions(suppressionsHash).then(() => {
-                    this.set('canSave', true);
-                    this.get('toast').info('Notification preferences saved successfully');
-                });
+            let account = this.get('sessionAccount.account');
+            var suppressionsHash = {};
+            Object.keys(suppressions).forEach(s => {
+                var suppression = suppressions[s];
+                suppressionsHash[`${suppression.id}`] = !suppression.subscribed;
+            });
+            account.setSuppressions(suppressionsHash).then(() => {
+                this.set('canSave', true);
+                this.get('toast').info('Notification preferences saved successfully');
             });
         }
     }

--- a/app/controllers/my/index.js
+++ b/app/controllers/my/index.js
@@ -4,7 +4,6 @@ import Ember from 'ember';
 const { bcrypt } = dcodeIO;
 
 export default Ember.Controller.extend({
-    sessionAccount: Ember.inject.service(),
     toast: Ember.inject.service(),
 
     _error: null,

--- a/app/controllers/my/index.js
+++ b/app/controllers/my/index.js
@@ -4,12 +4,12 @@ import Ember from 'ember';
 const { bcrypt } = dcodeIO;
 
 export default Ember.Controller.extend({
+    sessionAccount: Ember.inject.service(),
+    toast: Ember.inject.service(),
+
     _error: null,
     newPass: null,
     confirmPass: null,
-    sessionAccount: Ember.inject.service(),
-    account: Ember.computed.alias('sessionAccount.account'),
-    toast: Ember.inject.service(),
 
     passMatch: Ember.computed('newPass', 'confirmPass', function() {
         this.set('_error');
@@ -20,16 +20,16 @@ export default Ember.Controller.extend({
 
     actions: {
         save() {
-            this.get('account').save().then(() => {
+            this.get('model').save().then(() => {
                 this.toast.info('Account updated successfully.');
             });
         },
         cancel() {
-            this.get('account').rollbackAttributes();
+            this.get('model').rollbackAttributes();
         },
         updatePassword() {
-            this.set('account.password', bcrypt.hashSync(this.get('newPass'), 10).replace('$2a$', '$2b$'));
-            this.get('account').save().then(() => {
+            this.set('model.password', bcrypt.hashSync(this.get('newPass'), 10).replace('$2a$', '$2b$'));
+            this.get('model').save().then(() => {
                 this.set('_error', null);
                 this.set('newPass', null);
                 this.set('confirmPass', null);

--- a/app/controllers/participate.js
+++ b/app/controllers/participate.js
@@ -3,8 +3,7 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
     model: null,
     session: null,
-    sessionAccount: Ember.inject.service('session-account'),
-    store: Ember.inject.service(),
+
     isDirty: function() {
         // TODO: check the session model to see if it contains unsaved data
         var session = this.get('session');

--- a/app/controllers/studies.js
+++ b/app/controllers/studies.js
@@ -2,6 +2,5 @@ import Ember from 'ember';
 
 
 export default Ember.Controller.extend({
-    session: Ember.inject.service('session'),
-    sessionAccount: Ember.inject.service('session-account')
+    session: Ember.inject.service(),
 });

--- a/app/controllers/studies/detail.js
+++ b/app/controllers/studies/detail.js
@@ -25,7 +25,6 @@ export default Ember.Controller.extend({
     actions: {
         pickChild() {
             let profile = this.get('selectedChild');
-            this.get('sessionAccount').setProfile(profile);
             this.get('session').set('data.profile', profile);
             this.transitionToRoute('participate', this.get('model.id'));
         }

--- a/app/controllers/studies/detail.js
+++ b/app/controllers/studies/detail.js
@@ -2,14 +2,15 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
     session: Ember.inject.service(),
-    sessionAccount: Ember.inject.service(),
 
     account: null,
 
     selectedChildId: null,
     selectedChild: Ember.computed('selectedChildId', function () {
-        let account = this.get('sessionAccount').get('account');
-        return account.profileById(this.get('selectedChildId'));
+        let account = this.get('account');
+        if (account) {
+            return account.profileById(this.get('selectedChildId'));
+        }
     }),
 
     isAgeEligible: Ember.computed('selectedChild', function () {

--- a/app/controllers/studies/detail.js
+++ b/app/controllers/studies/detail.js
@@ -3,7 +3,9 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
     session: Ember.inject.service(),
     sessionAccount: Ember.inject.service(),
-    account: Ember.computed.alias('sessionAccount.account'),
+
+    account: null,
+
     selectedChildId: null,
     selectedChild: Ember.computed('selectedChildId', function () {
         let account = this.get('sessionAccount').get('account');

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,12 +1,4 @@
 import Ember from 'ember';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 
-export default Ember.Route.extend(ApplicationRouteMixin, {
-    session: Ember.inject.service('session'),
-    sessionAccount: Ember.inject.service('session-account'),
-    sessionAuthenticated() {
-        this._super(...arguments);
-        this.get('sessionAccount').load()
-            .catch(() => this.get('session').invalidate());
-    }
-});
+export default Ember.Route.extend(ApplicationRouteMixin);

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -5,8 +5,8 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
     session: Ember.inject.service('session'),
     sessionAccount: Ember.inject.service('session-account'),
     sessionAuthenticated() {
-        this.get('sessionAccount').loadCurrentUser()
-            .then(() => this._super(...arguments))
+        this._super(...arguments);
+        this.get('sessionAccount').load()
             .catch(() => this.get('session').invalidate());
     }
 });

--- a/app/routes/home/index.js
+++ b/app/routes/home/index.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-    session: Ember.inject.service('session'),
+    session: Ember.inject.service(),
 });

--- a/app/routes/my.js
+++ b/app/routes/my.js
@@ -6,7 +6,7 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
     sessionAccount: Ember.inject.service('session-account'),
 
     model() {
-        return this.get('sessionAccount').loadCurrentUser();
+        return this.get('sessionAccount').load();
     },
     beforeModel(transition) {
         if (transition.queryParams.access_token) {

--- a/app/routes/my.js
+++ b/app/routes/my.js
@@ -6,7 +6,7 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
     sessionAccount: Ember.inject.service('session-account'),
 
     model() {
-        return this.get('sessionAccount.account');
+        return this.get('sessionAccount').load();
     },
     beforeModel(transition) {
         if (transition.queryParams.access_token) {

--- a/app/routes/my.js
+++ b/app/routes/my.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
+import esaConfig from 'ember-simple-auth/configuration';
+
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
     session: Ember.inject.service(),
     sessionAccount: Ember.inject.service(),
@@ -9,14 +11,21 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
         return this.get('sessionAccount').load();
     },
     beforeModel(transition) {
-        if (transition.queryParams.access_token) {
+        let token = transition.queryParams.access_token;
+        if (this.get('session.isAuthenticated') || !token) {
+            // Either user is authenticated, or no token is present- either way, auth mixin should act normally
+            return this._super(...arguments);
+        } else {
+            // User is unauthenticated, but a token is present- we must bypass ESA so that user is automatically
+            //   logged in but remains on this page. (avoid race conditions between sessionAuthenticated events and super call)
+            transition.abort();
+            this.set('session.attemptedTransition', transition);
             return this.get('session')
-                .authenticate('authenticator:jam-jwt', {}, transition.queryParams.access_token)
-                .then(() => {
-                    window.location.hash = '';
-                    return this._super(...arguments);
-                });
+                .authenticate('authenticator:jam-jwt', {}, token)
+                .then(() => window.location.hash = '')
+                .catch(() => this.transitionTo(esaConfig.authenticationRoute));
+
+
         }
-        return this._super(...arguments);
     }
 });

--- a/app/routes/my.js
+++ b/app/routes/my.js
@@ -6,7 +6,7 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
     sessionAccount: Ember.inject.service('session-account'),
 
     model() {
-        return this.get('sessionAccount').load();
+        return this.get('sessionAccount.account');
     },
     beforeModel(transition) {
         if (transition.queryParams.access_token) {

--- a/app/routes/my.js
+++ b/app/routes/my.js
@@ -2,8 +2,8 @@ import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
-    session: Ember.inject.service('session'),
-    sessionAccount: Ember.inject.service('session-account'),
+    session: Ember.inject.service(),
+    sessionAccount: Ember.inject.service(),
 
     model() {
         return this.get('sessionAccount').load();

--- a/app/routes/my/children.js
+++ b/app/routes/my/children.js
@@ -1,4 +1,8 @@
 import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Ember.Route.extend(AuthenticatedRouteMixin, {});
+export default Ember.Route.extend(AuthenticatedRouteMixin, {
+    model() {
+        return this.modelFor('my');
+    }
+});

--- a/app/routes/my/email.js
+++ b/app/routes/my/email.js
@@ -1,4 +1,8 @@
 import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Ember.Route.extend(AuthenticatedRouteMixin, {});
+export default Ember.Route.extend(AuthenticatedRouteMixin, {
+    model() {
+        return this.modelFor('my');
+    }
+});

--- a/app/routes/my/index.js
+++ b/app/routes/my/index.js
@@ -1,3 +1,7 @@
 import Ember from 'ember';
 
-export default Ember.Route.extend({});
+export default Ember.Route.extend({
+    model() {
+        return this.modelFor('my');
+    }
+});

--- a/app/routes/participate.js
+++ b/app/routes/participate.js
@@ -6,9 +6,9 @@ import ExpPlayerRouteMixin from 'exp-player/mixins/exp-player-route';
 import WarnOnExitRouteMixin from 'exp-player/mixins/warn-on-exit-route';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, ExpPlayerRouteMixin, WarnOnExitRouteMixin, {
-    raven: Ember.inject.service('raven'),
+    raven: Ember.inject.service(),
 
-    sessionAccount: Ember.inject.service('session-account'),
+    sessionAccount: Ember.inject.service(),
 
     _getExperiment(params) {
         return this.store.findRecord('experiment', Ember.get(params, 'experiment_id'));

--- a/app/routes/studies/detail.js
+++ b/app/routes/studies/detail.js
@@ -1,9 +1,18 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+    sessionAccount: Ember.inject.service(),
+
     model(params) {
         return this.store.findRecord('experiment', params.experiment_id);
     },
+
+    setupController(controller) {
+        this._super(...arguments);
+        this.get('sessionAccount').load()
+            .then(user => controller.set('account', user));
+    },
+
     resetController: function(controller, isExiting) {
         if (isExiting) {
             controller.set('selectedChildId', null);

--- a/app/services/session-account.js
+++ b/app/services/session-account.js
@@ -4,11 +4,8 @@ export default Ember.Service.extend({
     session: Ember.inject.service(),
     store: Ember.inject.service(),
 
-    // FIXME: Deal with removed usages of profile field on service.
-    // FIXME: Removed setProfile method entirely, and rely on value living in one place (the session)
     profile: Ember.computed.alias('session.data.profile'),
 
-    // TODO: Can this be replaced with a simple alias?
     currentUserId: Ember.computed('session.data.authenticated', function() {
         var session = this.get('session');
         if (session.get('isAuthenticated')) {
@@ -20,7 +17,7 @@ export default Ember.Service.extend({
     /**
      * Fetch information about the currently logged in user. If no user is logged in, this method returns a rejected promise.
      * @method load
-     * @return {Promise}
+     * @return {Ember.RSVP.Promise}
      */
     load() {
         return new Ember.RSVP.Promise((resolve, reject) => {
@@ -28,13 +25,9 @@ export default Ember.Service.extend({
             if (!Ember.isEmpty(currentUserId)) {
                 var currentUser = this.get('store').peekRecord('account', currentUserId);
                 if (currentUser) {
-                    this.set('account', currentUser);
-                    resolve();
+                    resolve(currentUser);
                 } else {
-                    this.get('store').findRecord('account', currentUserId).then((user) => {
-                        this.set('account', user);
-                        resolve();
-                    }).catch(reject);
+                    this.get('store').findRecord('account', currentUserId).then(resolve, reject);
                 }
             } else {
                 reject();

--- a/app/services/session-account.js
+++ b/app/services/session-account.js
@@ -22,16 +22,19 @@ export default Ember.Service.extend({
      * @method load
      * @return {Promise}
      */
-    // TODO: Renamed loadCurrentUser to load, and changed return type
     load() {
         return new Ember.RSVP.Promise((resolve, reject) => {
             var currentUserId = this.get('currentUserId');
             if (!Ember.isEmpty(currentUserId)) {
                 var currentUser = this.get('store').peekRecord('account', currentUserId);
                 if (currentUser) {
-                    resolve(currentUser);
+                    this.set('account', currentUser);
+                    resolve();
                 } else {
-                    this.get('store').findRecord('account', currentUserId).then(resolve, reject);
+                    this.get('store').findRecord('account', currentUserId).then((user) => {
+                        this.set('account', user);
+                        resolve();
+                    }).catch(reject);
                 }
             } else {
                 reject();

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -4,7 +4,7 @@
   </div>
 {{else}}
   <div class="main">
-      {{main-nav}}
+      {{main-nav logout=(action 'logout')}}
       {{outlet}}
   </div>
 {{/if}}

--- a/app/templates/components/main-nav.hbs
+++ b/app/templates/components/main-nav.hbs
@@ -19,10 +19,8 @@
         <li>{{#link-to "resources"}}Resources{{/link-to}}</li>
         <li>{{#link-to "contact"}}Contact Us{{/link-to}}</li>
 	{{#if session.isAuthenticated}}
-	    {{#if accountName}}
-		<li>{{#link-to 'my'}}Hi {{accountName}}{{/link-to}}</li>
-	    {{/if}}
-            <li><a onclick={{action 'logout'}}>Logout</a></li>
+        <li>{{#link-to 'my'}}Hi {{accountName}}{{/link-to}}</li>
+        <li><a href="#" {{action logout}} class="btn-link">Logout</a></li>
 	{{else}}
             <li>{{#link-to 'login'}}Login{{/link-to}}</li>
 	{{/if}}

--- a/app/templates/my/children.hbs
+++ b/app/templates/my/children.hbs
@@ -4,10 +4,10 @@
   <br>
   <br>
   {{#bs-collapse collapsed=notAddingNew}}
-      {{edit-profile account=account profile=childProfile onAdd=(action 'profileAdded') onCancelAdd=(action 'cancelAddProfile')}}
+      {{edit-profile account=model profile=childProfile onAdd=(action 'profileAdded') onCancelAdd=(action 'cancelAddProfile')}}
   {{/bs-collapse}}
-  {{#each account.activeProfiles as |child|}}
-      {{edit-profile profile=child account=account}}
+  {{#each model.activeProfiles as |child|}}
+      {{edit-profile profile=child account=model}}
   {{/each}}
 </div>
 </div>

--- a/app/templates/my/demographics.hbs
+++ b/app/templates/my/demographics.hbs
@@ -7,18 +7,18 @@
     {{#bs-form}}
       {{#bs-form-group}}
         <label>What language(s) does your family speak at home?</label>
-        {{bs-input type="text" value=account.demographicsLanguagesSpokenAtHome}}
+        {{bs-input type="text" value=model.demographicsLanguagesSpokenAtHome}}
       {{/bs-form-group}}
       {{#bs-form-group}}
         <label>How many children do you have?</label>
-        <select onchange={{action (mut account.demographicsNumberOfChildren) value="target.value"}}
+        <select onchange={{action (mut model.demographicsNumberOfChildren) value="target.value"}}
           class="form-control">
           <option value="" disabled selected hidden>Please Choose...</option>
           {{#each childrenCounts as |childrenCount|}}
-          <option value={{childrenCount}} selected={{eq account.demographicsNumberOfChildren childrenCount}}>{{childrenCount}}</option>
+            <option value={{childrenCount}} selected={{eq model.demographicsNumberOfChildren childrenCount}}>{{childrenCount}}</option>
           {{/each}}
         </select>
-        {{#if (eq account.demographicsNumberOfChildren 'More than 10')}}
+        {{#if (eq model.demographicsNumberOfChildren 'More than 10')}}
         <br>
         <div class="form-inline">
           <label>I have {{bs-input class="form-control" type="text" value=nNumberOfChildren}} children</label>
@@ -54,85 +54,85 @@
         <br />If the answer varies due to shared custody arrangements or travel,
         please enter the number of parents/guardians your children are usually
         living with or explain below.
-        <select onchange={{action (mut account.demographicsNumberOfGuardians) value="target.value"}}
+        <select onchange={{action (mut model.demographicsNumberOfGuardians) value="target.value"}}
           class="form-control">
           <option value="" disabled selected hidden>Please Choose...</option>
           {{#each guardianOptions as |guardianOption|}}
-          <option value={{guardianOption}} selected={{eq account.demographicsNumberOfGuardians guardianOption}}>{{guardianOption}}</option>
+            <option value={{guardianOption}} selected={{eq model.demographicsNumberOfGuardians guardianOption}}>{{guardianOption}}</option>
           {{/each}}
         </select>
-        {{#if (eq account.demographicsNumberOfGuardians "varies")}}
+        {{#if (eq model.demographicsNumberOfGuardians "varies")}}
         <div class="col-md-12">
           <label>Additional information:</label>
-          {{bs-input type="text" value=account.demographicsNumberOfGuardiansExplanation}}
+          {{bs-input type="text" value=model.demographicsNumberOfGuardiansExplanation}}
         </div>
         {{/if}}
       {{/bs-form-group}}
       {{#bs-form-group}}
         <label>What category(ies) does your family identify as?</label>
         <div onchange={{action 'selectRaceIdentification' value='target'}} id="raceIdentification">
-            {{#each raceCategories as |raceCategory|}}
-              <label class="checkbox">
-            <input type="checkbox" value={{raceCategory}} checked={{include account.demographicsRaceIdentification raceCategory}}> {{raceCategory}}
-          </label>
+          {{#each raceCategories as |raceCategory|}}
+            <label class="checkbox">
+              <input type="checkbox" value={{raceCategory}} checked={{include model.demographicsRaceIdentification raceCategory}}> {{raceCategory}}
+            </label>
           {{/each}}
         </div>
       {{/bs-form-group}}
       {{#bs-form-group}}
         <label>What is your age?</label>
-        <select onchange={{action (mut account.demographicsAge) value="target.value"}} class="form-control" >
+        <select onchange={{action (mut model.demographicsAge) value="target.value"}} class="form-control" >
           <option value="" disabled selected hidden>Please Choose...</option>
           {{#each ageChoices as |ageChoice|}}
-          <option value={{ageChoice}} selected={{eq account.demographicsAge ageChoice}}>{{ageChoice}}</option>
+            <option value={{ageChoice}} selected={{eq model.demographicsAge ageChoice}}>{{ageChoice}}</option>
           {{/each}}
         </select>
       {{/bs-form-group}}
       {{#bs-form-group}}
         <label>What is your gender?</label>
-        <select onchange={{action (mut account.demographicsGender) value="target.value"}} class="form-control" >
+        <select onchange={{action (mut model.demographicsGender) value="target.value"}} class="form-control" >
           <option value="" disabled selected hidden>Please Choose...</option>
           {{#each genderOptions as |genderOption|}}
-          <option value={{genderOption}} selected={{eq account.demographicsGender genderOption}}>{{genderOption}}</option>
+            <option value={{genderOption}} selected={{eq model.demographicsGender genderOption}}>{{genderOption}}</option>
           {{/each}}
         </select>
       {{/bs-form-group}}
       {{#bs-form-group}}
         <label>What is the highest level of education you've completed?</label>
-        <select onchange={{action (mut account.demographicsEducationLevel) value="target.value"}} class="form-control" >
+        <select onchange={{action (mut model.demographicsEducationLevel) value="target.value"}} class="form-control" >
           <option value="" disabled selected hidden>Please Choose...</option>
           {{#each educationOptions as |educationOption|}}
-          <option value={{educationOption}} selected={{eq account.demographicsEducationLevel educationOption}}>{{educationOption}}</option>
+            <option value={{educationOption}} selected={{eq model.demographicsEducationLevel educationOption}}>{{educationOption}}</option>
           {{/each}}
         </select>
       {{/bs-form-group}}
       {{#bs-form-group}}
         <label>What is the highest level of education your spouse has completed?</label>
-        <select onchange={{action (mut account.demographicsSpouseEducationLevel) value="target.value"}} class="form-control" >
+        <select onchange={{action (mut model.demographicsSpouseEducationLevel) value="target.value"}} class="form-control" >
           <option value="" disabled selected hidden>Please Choose...</option>
           {{#each spouseEducationOptions as |spouseEducationOption|}}
-          <option value={{spouseEducationOption}} selected={{eq account.demographicsSpouseEducationLevel spouseEducationOption}}>{{spouseEducationOption}}</option>
+            <option value={{spouseEducationOption}} selected={{eq model.demographicsSpouseEducationLevel spouseEducationOption}}>{{spouseEducationOption}}</option>
           {{/each}}
         </select>
       {{/bs-form-group}}
       {{#bs-form-group}}
         <label>What is your approximate family yearly income (in US dollars)?</label>
-        <select onchange={{action (mut account.demographicsAnnualIncome) value="target.value"}} class="form-control" >
+        <select onchange={{action (mut model.demographicsAnnualIncome) value="target.value"}} class="form-control" >
           <option value="" disabled selected hidden>Please Choose...</option>
           {{#each annualIncomeOptions as |annualIncomeOption|}}
-          <option value={{annualIncomeOption}} selected={{eq account.demographicsAnnualIncome annualIncomeOption}}>{{annualIncomeOption}}</option>
+           <option value={{annualIncomeOption}} selected={{eq model.demographicsAnnualIncome annualIncomeOption}}>{{annualIncomeOption}}</option>
           {{/each}}
         </select>
       {{/bs-form-group}}
       {{#bs-form-group}}
         <label>About how many children's books are there in your home?</label>
-        {{bs-input type="number" value=account.demographicsNumberOfBooks min=0}}
-	{{#if (not (gte account.demographicsNumberOfBooks 0)) }}
+        {{bs-input type="number" value=model.demographicsNumberOfBooks min=0}}
+	{{#if (not (gte model.demographicsNumberOfBooks 0)) }}
 	  <span class="text-danger">Please enter a value greater than or equal to zero</span>
 	{{/if}}
       {{/bs-form-group}}
       {{#bs-form-group}}
         <label>Anything else you'd like us to know?</label>
-        {{bs-textarea value=account.demographicsAdditionalComments}}
+        {{bs-textarea value=model.demographicsAdditionalComments}}
       {{/bs-form-group}}
       <br />
       {{#bs-button type="success" action="saveDemographicsPreferences" disabled=(not isValid) class="pull-right"}}Save{{/bs-button}}

--- a/app/templates/my/email.hbs
+++ b/app/templates/my/email.hbs
@@ -25,14 +25,14 @@
 	{{/each}}
 	<br>
 	  {{#if canSave}}
-            {{#bs-button type="success" action=(action 'saveEmailPreferences' model.account)}}
+            {{#bs-button type="success" action=(action 'saveEmailPreferences')}}
               Save
             {{/bs-button}}
 	  {{else}}
 	    {{#bs-button class="disabled" type="success" disabled=true}}
 	      Saving
 	    {{/bs-button}}
-	  {{/if}}	  
+	  {{/if}}
       {{/bs-form-group}}
     {{/bs-form}}
   </div>

--- a/app/templates/my/index.hbs
+++ b/app/templates/my/index.hbs
@@ -4,27 +4,27 @@
   <div class="form-group">
     <label class="col-sm-2 control-label">Username</label>
     <div class="col-sm-10">
-      <input class="form-control" value="{{account.username}}" disabled>
+      <input class="form-control" value="{{model.username}}" disabled>
     </div>
   </div>
   <div class="form-group">
     <label class="col-sm-2 control-label">Contact Name</label>
     <div class="col-sm-10">
-        {{input value=account.name class="form-control"}}
+        {{input value=model.name class="form-control"}}
     </div>
   </div>
   <div class="form-group">
     <label for="inputPassword3" class="col-sm-2 control-label">Email</label>
     <div class="col-sm-10">
-        {{input value=account.email class="form-control"}}
+        {{input value=model.email class="form-control"}}
     </div>
   </div>
   <div class="form-group">
     <div class="col-sm-offset-4 col-sm-8">
         <div class="pull-right">
-            <button disabled={{not account.hasDirtyAttributes}} {{action 'save'}} class="btn btn-success">Save</button>
+            <button disabled={{not model.hasDirtyAttributes}} {{action 'save'}} class="btn btn-success">Save</button>
             &nbsp;
-            <button disabled={{not account.hasDirtyAttributes}} {{action 'cancel'}} class="btn btn-default">Cancel</button>
+            <button disabled={{not model.hasDirtyAttributes}} {{action 'cancel'}} class="btn btn-default">Cancel</button>
         </div>
     </div>
   </div>


### PR DESCRIPTION
# Purpose
A regression in a recent bugfix caused the user to stay at the login page after logging in.

Additional changes were made while working on this, as described below.

# Testing notes / requirements
## Cross browser
- Everything below should work in:
 - [x] Chrome
 - [x] Firefox

## Normal login
- [x] If a user clicks the login button, successful login should take them to the homepage.
- [x] If they are logged in and refresh, their username should still appear in the navbar. (no regression of sessionAccount.account not being set in absence of a sessionAuthenticated event)
- [x] If they are already logged in, and try to visit `/login`, they should be taken to the index page
- [x] If a user is trying to visit a route that requires authentication, successful login should take them to the route they were previously trying to reach.

## Password reset behavior
- [x] If a user clicks an expired password reset link, they should be taken back to the login page
- [x] If the user clicks an expired password reset link with a malformed token, they should be taken back to the login page (the page should not hang)
- [x] If a user clicks a valid password reset link while logged out, they should be logged in, and be taken to the account page
- [x] If a user clicks a password reset link while already logged in, they should remain logged in, and be taken to the account page

## Miscellaneous
- [x] Experiment pages and remainder of site should render correctly
- [x] Profile pages should prefill profile information
- [x] Payload sent to server should correctly identify the chosen user and profile

# Summary of changes
Get all of the above working at same time.
- Make sure that user is redirected appropriately after login
- Send username and password to the server as written, instead of trimming spaces. (more consistent with how handled on backend)
- Fix issues where app sometimes hung if given a malformed access token
- Fix race condition where `sessionAccount.account` was not always available when page loaded
- Fix race condition with page transitions (events and promise resolutions were not always occurring in a reliable order)
- Fix sporadic issues where `sessionAccount.account` might not be set correctly after page refresh
- Various minor style and consistency cleanup
- sessionAccount.profile should be an alias, not a separate data storage location.