### PR TITLE
Refactor player to extract Lookit-specific exit behaviors

### DIFF
--- a/app/components/exp-player.js
+++ b/app/components/exp-player.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+import ExpPlayer from 'exp-player/components/exp-player';
+
+export default ExpPlayer.extend({
+    _registerHandlers() {
+        this._super();
+        Ember.$(window).on('keyup', (e) => {
+            if (e.which === 112) { // F1 key
+                this.send('exitEarly');
+            }
+        });
+    },
+    _removeHandlers() {
+        Ember.$(window).off('keypress');
+        return this._super();
+    },
+    actions: {
+        exitEarly() {
+            this.set('hasAttemptedExit', false);
+            // Save any available data immediately
+            this.send('setGlobalTimeEvent', 'exitEarly', {
+                exitType: 'manualInterrupt',  // User consciously chose to exit, eg by pressing F1 key
+                lastPageSeen: this.get('frameIndex') + 1
+            });
+            this.get('session').save();
+
+            // Navigate to last page in experiment (assumed to be survey frame)
+            var max = this.get('frames.length') - 1;
+            this.set('frameIndex', max);
+        },
+    }
+});

--- a/app/components/exp-player.js
+++ b/app/components/exp-player.js
@@ -2,6 +2,22 @@ import Ember from 'ember';
 import ExpPlayer from 'exp-player/components/exp-player';
 
 export default ExpPlayer.extend({
+    toast: Ember.inject.service(),
+
+    messageEarlyExitModal: `
+If you're sure you'd like to leave this study early
+you can do so now.
+
+We'd appreciate it if before you leave you fill out a
+very brief exit survey letting us know how we can use
+any video captured during this session. Press 'Stay on
+this Page' and you will be prompted to go to this
+exit survey.
+
+If leaving this page was an accident you will be
+able to continue the study.
+`,
+
     _registerHandlers() {
         this._super();
         Ember.$(window).on('keyup', (e) => {
@@ -13,6 +29,12 @@ export default ExpPlayer.extend({
     _removeHandlers() {
         Ember.$(window).off('keypress');
         return this._super();
+    },
+    beforeUnload() {
+        if (!this.get('allowExit')) {
+            this.get('toast').warning('To leave the study early, please press F1 and then select a privacy level for your videos');
+        }
+        this._super(...arguments);
     },
     actions: {
         exitEarly() {

--- a/app/components/exp-player.js
+++ b/app/components/exp-player.js
@@ -34,7 +34,7 @@ able to continue the study.
         if (!this.get('allowExit')) {
             this.get('toast').warning('To leave the study early, please press F1 and then select a privacy level for your videos');
         }
-        this._super(...arguments);
+        return this._super(...arguments);
     },
     actions: {
         exitEarly() {


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-267

## Purpose
See https://github.com/CenterForOpenScience/exp-addons/pull/171

## Summary of changes
See linked PR.

## Testing notes
Look that existing expected functionality remains unchanged for Lookit.
- [x] Verify that experiment can exit early by pressing F1
- [x] Verify that experiment logs early exit warnings when trying to leave page


## TODO
- [ ] Update submodule commit when addons PR is merged, then merge this one