### PR TITLE
Past studies page should limit results to those where consent was provided

### DIFF
--- a/app/routes/studies/history.js
+++ b/app/routes/studies/history.js
@@ -5,32 +5,32 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
 
     model( /*params*/ ) {
+        // In the future, routes should be restructured to better support more experiments
         let Experiment = this.store.modelFor('experiment');
+        let experiments = this.store.query('experiment', {
+            q: `state:${Experiment.prototype.ACTIVE} OR state:${Experiment.prototype.ARCHIVED}`
+        });
+
+        let sessionPromises = [];
+        let experimentSessions = [];
 
         // Return the result of a query for all experiments
-        return this.store.query('experiment', {
-            q: `state:${Experiment.prototype.ACTIVE} OR state:${Experiment.prototype.ARCHIVED}`
-        }).then((experiments) => {
-            let promises = [];
-            let experimentSessions = [];
-
+        return experiments.then((experiments) => {
             experiments.forEach((experiment) => {
-                promises.push( // Endpoint only returns sessions that the user has permissions to see (assumption: only their own)
-                    this.store.query(experiment.get('sessionCollectionId'), {
-                        'filter[completed]': 1
-                    }).then((sessions) => {
-                        if (sessions.get('length') > 0) {
-                            experimentSessions.push({
-                                experiment: experiment,
-                                sessions: sessions
-                            });
-                        }
-                    }));
+                // Endpoint only returns sessions that the user has permissions to see (assumption: for a Jam user, this means only their own sessions)
+                let foundSessions = this.store.query(experiment.get('sessionCollectionId'), {
+                    'filter[completed]': 1
+                }).then((sessions) => {
+                    if (sessions.get('length') > 0) {
+                        experimentSessions.push({
+                            experiment: experiment,
+                            sessions: sessions
+                        });
+                    }
+                });
+                sessionPromises.push(foundSessions);
             });
-
-            return Ember.RSVP.all(promises).then(() => {
-                return experimentSessions;
-            });
+            return Ember.RSVP.all(sessionPromises).then(() => experimentSessions);
         });
     }
 });

--- a/app/routes/studies/history.js
+++ b/app/routes/studies/history.js
@@ -18,8 +18,10 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
         return experiments.then((experiments) => {
             experiments.forEach((experiment) => {
                 // Endpoint only returns sessions that the user has permissions to see (assumption: for a Jam user, this means only their own sessions)
+                // Rule: show all videos with a consent recording even if not complete, enabling visible feedback for partial sessions
                 let foundSessions = this.store.query(experiment.get('sessionCollectionId'), {
-                    'filter[completed]': 1, 'page[size]': 100
+                    'sort': '-created_on',
+                    'page[size]': 100
                 }).then((sessions) => {
                     // Only show sessions where expData contains a key with information about the consent frame
                     // TODO: For now, this is an extremely Lookit-specific way of identifying the consent page, pending LEI-272

--- a/app/services/session-account.js
+++ b/app/services/session-account.js
@@ -1,5 +1,14 @@
 import Ember from 'ember';
 
+/**
+ * @module lookit
+ * @submodule services
+ */
+
+/**
+ * A service for accessing information about the currently logged-in user
+ * @class sessionAccount
+ */
 export default Ember.Service.extend({
     session: Ember.inject.service(),
     store: Ember.inject.service(),


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-266

## Purpose
Allow the "past studies" page to exclude any sessions where user had not provided consent.

...but it should show even completed studies.

## Design questions
We have elected to show any session, in case there is feedback on a failed one.

We will not impose judgment on whether consent video is valid, only that it exists.

For now, results will be limited to 100. Sorting newest first helps avoid appearance of significant data loss. (the long term fix will be to correctly implement pagination on this route, in a full redesign of the page)

## Summary of changes
- Lightly refactor the model hook for readability
- Fetch max pagesize from API, as temp fix for prolific participants (until we can get around to better handling of pagination)

## Testing notes
Users will see more studies now because - and user should never have gotten to the final page unless they had completed the consent page. (barring possible F1 edge case). Thus the resulting user experience should be identical.


Observable changes:
- More studies will be seen: not just those marked as completed
  - If user did not even make a consent video, study will not be visible in list
- Studies will now be sorted as newest first, to help keep recent feedback near the top
