### PR TITLE
Fix issue where failing to sign up with a username- twice- hangs the …

### DIFF
--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -15,6 +15,7 @@ export default Ember.Controller.extend({
 
     resetId: null,
     resetSent: false,
+
     actions: {
         authenticate(attrs) {
             return this.get('session')
@@ -28,14 +29,12 @@ export default Ember.Controller.extend({
         createAccount(attrs) {
             this.set('creatingUser', true);
             var newAccount = this.store.createRecord('account', {
-                username: attrs.username,
                 password: attrs.password,
                 email: attrs.email,
                 profiles: [],
                 emailPreferencesNextSession: true,
                 emailPreferencesNewStudies: true,
                 emailPreferencesResultsPublished: true,
-                // Update the line below to be more general
                 id: `${attrs.username}`
             });
             newAccount.save().then(() => {
@@ -49,6 +48,8 @@ export default Ember.Controller.extend({
                 };
                 this.send('authenticate', theAttrs);
             }).catch((res) => {
+                // Remove the failed record from the store so that user can try again
+                this.store.unloadRecord(newAccount);
                 this.set('creatingUser', false);
                 if (res.errors[0].status === '409') {
                     this.send('toggleUserConflict');


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-274

## Purpose
Fix issue where two consecutive failures to register with the same username caused app to hang.

This appeared several times in production sentry after new user emails were sent out.

## Summary of changes
- Remove username field from payload (it's now just an alias for the ID)
- If user creation fails due, unload the created-but-unsaved record from the store so that we can try again without createRecord throwing an error.

## Testing notes
Steps to reproduce:
1. Try to create an account whose username is already taken.
2. After it fails, hit create account again without changing the information.

Expected result:
1. A client-side error saying the user name is already taken

Actual result:
The "Creating your account" modal hangs indefinitely, and the console displays an unhandled error:
"Assertion Failed: The id abought has already been used with another record of type lookit-base@model:account:."