### PR TITLE
Demographics page tweaks

### DIFF
--- a/app/templates/contact.hbs
+++ b/app/templates/contact.hbs
@@ -16,9 +16,29 @@
         </p>
         <h3>For researchers</h3>
 
-        <p>We are committed to making Lookit a tool for all developmental researchers and to keeping the code open-source. You can view the current <a href="https://github.com/CenterForOpenScience/lookit" target=_blank>Lookit</a>, <a href="https://github.com/CenterForOpenScience/experimenter" target=_blank>Experimenter</a>, and <a href="https://github.com/CenterForOpenScience/exp-addons" target=_blank>exp-addons</a> (specific frames for Lookit studies) codebases on github; <a href="https://github.com/kimberscott?tab=repositories" target=_blank>Kim's forks</a> may have more up-to-date versions of data analysis code. </p>
+        <p>
+            We are committed to making Lookit a tool for all developmental researchers and to keeping the code
+            open-source. You can view the current <a href="https://github.com/CenterForOpenScience/lookit" target=_blank>Lookit</a>,
+            <a href="https://github.com/CenterForOpenScience/experimenter" target=_blank>Experimenter</a>, and
+            <a href="https://github.com/CenterForOpenScience/exp-addons" target=_blank>exp-addons</a> (specific
+            frames for Lookit studies) codebases on github; <a href="https://github.com/kimberscott?tab=repositories" target=_blank>Kim's forks</a>
+            may have more up-to-date versions of data analysis code.
+        </p>
 
-        <p>We're not quite ready to start hosting additional studies from other labs yet, but our partners at the Center for Open Science are actively developing functionality for multiple labs to create and post their own studies on Lookit. Although we aim for the platform to be as accessible as possible, some familiarity with programming basics will be helpful for researchers. An ideal skillset for creating your own studies would include basic understanding of HTML, CSS, and JavaScript for study creation; passing familiarity with the <a href="https://guides.emberjs.com/v2.9.0/" target=_blank>Ember framework</a> used by Lookit and Experimenter; and python for data processing.</p>
-        <p>For updates on the Lookit platform and discussions about collaboration opportunities, you can <a  href="http://mailman.mit.edu/mailman/listinfo/lookit-research" target=_blank>join the lookit-research email list</a>.  Several initial test studies of a prototype Lookit platform were completed in 2015; please email Kim Scott (kimscott@mit.edu) if you'd like in-press manuscripts describing the results.</p>
+        <p>
+            We're not quite ready to start hosting additional studies from other labs yet, but our partners at the
+            Center for Open Science are actively developing functionality for multiple labs to create and post their
+            own studies on Lookit. Although we aim for the platform to be as accessible as possible, some familiarity
+            with programming basics will be helpful for researchers. An ideal skillset for creating your own studies
+            would include basic understanding of HTML, CSS, and JavaScript for study creation; passing familiarity with
+            the <a href="https://guides.emberjs.com/v2.8.0/" target=_blank>Ember framework</a> used by Lookit and
+            Experimenter; and python for data processing.
+        </p>
+        <p>
+            For updates on the Lookit platform and discussions about collaboration opportunities, you can
+            <a  href="http://mailman.mit.edu/mailman/listinfo/lookit-research" target=_blank>join the lookit-research
+                email list</a>.  Several initial test studies of a prototype Lookit platform were completed in 2015;
+            please email Kim Scott (kimscott@mit.edu) if you'd like in-press manuscripts describing the results.
+        </p>
     </div>
 </div>

--- a/app/templates/my/demographics.hbs
+++ b/app/templates/my/demographics.hbs
@@ -37,13 +37,13 @@
       {{/if}}
 
       {{#bs-form-group}}
-      <label>How would you describe the area where you live?</label>
-      <select onchange={{action (mut model.demographicsDensity) value="target.value"}} class="form-control">
-        <option value="" disabled selected hidden>Please choose...</option>
-          {{#each densityOptions as |densityOption|}}
-            <option value={{densityOption}} selected={{eq model.demographicsDensity densityOption}}>{{densityOption}}</option>
-          {{/each}}
-      </select>
+          <label>How would you describe the area where you live?</label>
+          <select onchange={{action (mut model.demographicsDensity) value="target.value"}} class="form-control">
+            <option value="" disabled selected hidden>Please choose...</option>
+            {{#each densityOptions as |densityOption|}}
+              <option value={{densityOption}} selected={{eq model.demographicsDensity densityOption}}>{{densityOption}}</option>
+            {{/each}}
+          </select>
       {{/bs-form-group}}
 
       {{#bs-form-group}}
@@ -78,11 +78,11 @@
             <div class="col-xs-11">
               <div class="input-group">
                 {{pikaday-input value=(unbound bd) onPikadaySelect=(action 'setChildBirthday' index) format="MM/DD/YYYY" yearRange="1990,currentYear" maxDate=today class="form-control"}}
-                <span class="input-group-addon">
-                  {{#if bd}}
-                    {{age bd hideSuffix=true}} old
-                  {{/if}}
-                </span>
+                {{#if bd}}
+                    <span class="input-group-addon">
+                        {{age bd hideSuffix=true}} old
+                    </span>
+                {{/if}}
               </div>
             </div>
           </div>
@@ -102,13 +102,14 @@
             <option value={{guardianOption}} selected={{eq model.demographicsNumberOfGuardians guardianOption}}>{{guardianOption}}</option>
           {{/each}}
         </select>
-        {{#if (eq model.demographicsNumberOfGuardians "varies")}}
-        <div class="col-md-12">
-          <label>Additional information:</label>
-          {{bs-input type="text" value=model.demographicsNumberOfGuardiansExplanation}}
-        </div>
-        {{/if}}
       {{/bs-form-group}}
+      {{#bs-form-group}}
+          {{#if (eq model.demographicsNumberOfGuardians "varies")}}
+              <label>If you answered "varies" above, please explain:</label>
+                  {{bs-input type="text" value=model.demographicsNumberOfGuardiansExplanation}}
+          {{/if}}
+      {{/bs-form-group}}
+
       {{#bs-form-group}}
         <label>What category(ies) does your family identify as?</label>
         <div onchange={{action 'selectRaceIdentification' value='target'}} id="raceIdentification">


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-308

## Purpose
Fix presentation, layout, and broken field on demographics page.

While fixing the "explain number of guardians" field, also change wording to make this field slightly more clear. (pinging @kimberscott for approval of user-facing language)

Old wording:
> Additional information:

New wording:
> If you answered "varies" above, please explain:

## Summary of changes
Before:
![screen shot 2016-11-07 at 2 34 49 pm](https://cloud.githubusercontent.com/assets/2957073/20074726/7fa6aea8-a4ff-11e6-8f29-f96958bd61a4.png)
![screen shot 2016-11-07 at 3 34 02 pm](https://cloud.githubusercontent.com/assets/2957073/20074789/b8115d88-a4ff-11e6-9175-967cee7cc268.png)

After
![screen shot 2016-11-07 at 3 34 26 pm](https://cloud.githubusercontent.com/assets/2957073/20074783/b38a44f0-a4ff-11e6-97ec-5ff6d08b0367.png)

![screen shot 2016-11-07 at 3 29 45 pm](https://cloud.githubusercontent.com/assets/2957073/20074756/991bd548-a4ff-11e6-81ea-5816ccf1b398.png)


## Testing notes
New page should match "after" screenshots above. Visit demographics page, and add a second child without specifying age information about that child.