### PR TITLE
Fix F1 early exit behavior

### DIFF
--- a/.ember-cli
+++ b/.ember-cli
@@ -5,5 +5,7 @@
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
-  "disableAnalytics": false
+  "disableAnalytics": false,
+
+  "usePods": true
 }

--- a/app/components/exp-player/component.js
+++ b/app/components/exp-player/component.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ExpPlayer from 'exp-player/components/exp-player';
+import ExpPlayer from 'exp-player/components/exp-player/component';
 
 export default ExpPlayer.extend({
     toast: Ember.inject.service(),


### PR DESCRIPTION
Refs: (no ticket)

## Purpose
Fix an issue where the player did not correctly register the F1-to-exit-early behavior. Ember was not correctly finding the modified component definition after the recent changeover to pod-style components.

## Summary of changes

- Rule change: all new components will be pod-style unless specified otherwise
- Fix issue where player component was not being correctly registered/extended due to a mismatch between pod-style and non-pod-style components. (symptom: f1 early exit behavior was broken)
- Update submodule commit

## Testing notes
- Start an experiment. During one of the videos, try to exit a session early by pressing f1. You should go to the exit survey.
- Pause the study (esc), then try to leave the page, and click stay on the modal that appears. You should see a toast message.
- Try to create a new component: `ember g component delete-me`. It should be created as a pod (JS and template in same folder).
  - This option silently inverts the meaning of `--pod`, which will now make it *not* be a pod. This is unfortunately confusing to experienced ember-cli users, but based on current usage case, making pods the default seems the best favorable course.