### PR TITLE
Add error handling for case when Sendgrid settings fail

### DIFF
--- a/app/controllers/my/email.js
+++ b/app/controllers/my/email.js
@@ -30,9 +30,9 @@ export default Ember.Controller.extend({
                 suppressionsHash[`${suppression.id}`] = !suppression.subscribed;
             });
             account.setSuppressions(suppressionsHash).then(() => {
-                this.set('canSave', true);
                 this.get('toast').info('Notification preferences saved successfully');
-            }).catch(() => this.get('toast').error('Could not update notification preferences. If the problem persists, please contact support.'));
+            }).catch(() => this.get('toast').error('Could not update notification preferences. If the problem persists, please contact support.')
+            ).finally(() => this.set('canSave', true));
         }
     }
 });

--- a/app/controllers/my/email.js
+++ b/app/controllers/my/email.js
@@ -32,7 +32,7 @@ export default Ember.Controller.extend({
             account.setSuppressions(suppressionsHash).then(() => {
                 this.set('canSave', true);
                 this.get('toast').info('Notification preferences saved successfully');
-            });
+            }).catch(() => this.get('toast').error('Could not update notification preferences. If the problem persists, please contact support.'));
         }
     }
 });


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-275

## Purpose
Provide user error messaging around email settings failure. This adds cosmetic improvements around a current issue.

This PR must be shipped alongside an accompanying build change, so that the [dockerfile](https://github.com/CenterForOpenScience/docker-library/blob/master/lookit/Dockerfile#L87) builds with `--environment production` in production. Using the wrong sendgrid group IDs in production is the root cause.

## Summary of changes
Add a toast error message when sendgrid network requests fail with error 500.
https://github.com/CenterForOpenScience/docker-library/blob/master/lookit/Dockerfile#L87

(See linked JIRA ticket for associated JamDB sentry issue regarding JamDB error handling)

## Testing notes

The below steps to reproduce describe the original bug. 
- Create an account on `lookit.mit.edu`
- Visit the [email prefs page](https://lookit.mit.edu/account/email), uncheck all boxes, and save your preferences
- The page will hang. If you make this request with the network tab open, then you will see a failed request in the console (500 error to JamDB).

Specific observable consequence is best explained by this code snippet: https://github.com/abought/lookit-1/blob/d49451de061e18fdf45e4461f8cab9efcd21fad0/config/environment.js#L47-L95
In the screenshot above, you see group IDs like “1117” in the failed url. That is a group ID associated with staging. The correct production suppression IDs that we expect to appear in that URL are 915, 917, 919, and 921


To test the new error messaging:
- Running the lookit ember app locally, change a sendgrid email group ID in config/environment.js . (see above linked snippet) Eg:

```
            nextSession: {
                label: 'Next Session',
                description: 'It\'s time for another session of a study we are currently participating in',
                id: '00000000'
            },
```
If the ID is unrecognized, then changing email settings from the preferences page should result in an error message reading "Could not update notification preferences", rather than the page hanging.

[#LEI-275]