### PR TITLE
Ensure that app runs when built in production mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ JAMDB_URL=https://staging-metadata.osf.io
 JAMDB_NAMESPACE=experimenter
 
 SENTRY_DSN=""
+# One of "staging" or "production"
+SENDGRID_ENV="staging"
 ```
 
 A more complete configuration string is available upon request. In this application, we typically use `WOWZA_PHP` 

--- a/app/routes/studies.js
+++ b/app/routes/studies.js
@@ -1,10 +1,11 @@
 import Ember from 'ember';
 
+import {expStates} from 'exp-models/models/experiment';
+
 export default Ember.Route.extend({
     model() {
-        let Experiment = this.store.modelFor('experiment');
         return this.store.query('experiment', {
-            q:`state:${Experiment.ACTIVE}`
+            q:`state:${expStates.ACTIVE}`
         });
     }
 });

--- a/app/routes/studies.js
+++ b/app/routes/studies.js
@@ -4,7 +4,7 @@ export default Ember.Route.extend({
     model() {
         let Experiment = this.store.modelFor('experiment');
         return this.store.query('experiment', {
-            q:`state:${Experiment.prototype.ACTIVE}`
+            q:`state:${Experiment.ACTIVE}`
         });
     }
 });

--- a/app/routes/studies/history.js
+++ b/app/routes/studies/history.js
@@ -2,13 +2,14 @@ import Ember from 'ember';
 
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
+import {expStates} from 'exp-models/models/experiment';
+
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
 
     model( /*params*/ ) {
         // In the future, routes should be restructured to better support more experiments
-        let Experiment = this.store.modelFor('experiment');
         let experiments = this.store.query('experiment', {
-            q: `state:${Experiment.ACTIVE} OR state:${Experiment.ARCHIVED}`
+            q: `state:${expStates.ACTIVE} OR state:${expStates.ARCHIVED}`
         });
 
         let sessionPromises = [];

--- a/app/routes/studies/history.js
+++ b/app/routes/studies/history.js
@@ -8,7 +8,7 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
         // In the future, routes should be restructured to better support more experiments
         let Experiment = this.store.modelFor('experiment');
         let experiments = this.store.query('experiment', {
-            q: `state:${Experiment.prototype.ACTIVE} OR state:${Experiment.prototype.ARCHIVED}`
+            q: `state:${Experiment.ACTIVE} OR state:${Experiment.ARCHIVED}`
         });
 
         let sessionPromises = [];

--- a/config/environment.js
+++ b/config/environment.js
@@ -27,24 +27,9 @@ module.exports = function (environment) {
         }
     };
 
-    if (environment === 'development') {
-        // ENV.APP.LOG_RESOLVER = true;
-        // ENV.APP.LOG_ACTIVE_GENERATION = true;
-        // ENV.APP.LOG_TRANSITIONS = true;
-        // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
-        // ENV.APP.LOG_VIEW_LOOKUPS = true;
-    }
-
-    if (environment === 'staging' || environment === 'production') {
-        ENV.JAMDB = {
-            authorizer: 'jam-jwt',
-            collection:'accounts',
-            url: process.env.JAMDB_URL,
-            namespace: process.env.JAMDB_NAMESPACE
-        };
-    }
-
-    if (environment === 'staging') {
+    // For now, just hardcode the sendgrid group IDs for both environments. In future switch to YML config and store
+    //   this data as an object in .env files
+    if (process.env.SENDGRID_ENV === 'staging') {
         ENV.ASM_MAPPING = {
             nextSession: {
                 label: 'Next Session',
@@ -67,9 +52,7 @@ module.exports = function (environment) {
                 id: '1117'
             }
         };
-    }
-
-    if (environment === 'production') {
+    } else if (process.env.SENDGRID_ENV === 'production') {
         ENV.ASM_MAPPING = {
             nextSession: {
                 label: 'Next Session',
@@ -103,6 +86,14 @@ module.exports = function (environment) {
         ENV.APP.LOG_VIEW_LOOKUPS = false;
 
         ENV.APP.rootElement = '#ember-testing';
+    } else {
+        // Get application configuration from .env file
+        ENV.JAMDB = {
+            authorizer: 'jam-jwt',
+            collection:'accounts',
+            url: process.env.JAMDB_URL,
+            namespace: process.env.JAMDB_NAMESPACE
+        };
     }
 
     return ENV;


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-275

⚠️ Must be paired with Docker deployment changes and exp-addons PR

## Purpose
Production site should build in production mode. Fix ember syntax errors revealed by building this way.

## Summary of changes
- Make `.env` file solely responsible for machine-specific config
- Fix `model.prototype` code that didn't work in production

## Testing notes
General re-QA of site.

## Deployment notes
- Must be paired with a docker-library PR to change how app is built
- Must update the `.env` private configs for both staging and production sites, to add a `SENDGRID_ENV` key as noted in the README.