### PR TITLE
Update sendgrid opt-out prefs when updating email subscriptions

### DIFF
--- a/app/controllers/my/email.js
+++ b/app/controllers/my/email.js
@@ -25,9 +25,8 @@ export default Ember.Controller.extend({
             this.set('canSave', false);
             let account = this.get('model');
             var suppressionsHash = {};
-            Object.keys(suppressions).forEach(s => {
-                var suppression = suppressions[s];
-                suppressionsHash[`${suppression.id}`] = !suppression.subscribed;
+            suppressions.forEach(s => {
+                suppressionsHash[`${s.id}`] = !s.subscribed;
             });
             account.setSuppressions(suppressionsHash).then(() => {
                 this.get('toast').info('Notification preferences saved successfully');

--- a/app/controllers/my/index.js
+++ b/app/controllers/my/index.js
@@ -17,11 +17,39 @@ export default Ember.Controller.extend({
 
     canUpdate: Ember.computed.and('newPass', 'confirmPass', 'passMatch'),
 
+    _updateAccount() {
+        return this.get('model').save()
+            .then(() => this.toast.info('Account updated successfully.'))
+            .catch(()=> this.toast.error('Could not update account details at this time; please try again later.'));
+    },
+
     actions: {
         save() {
-            this.get('model').save().then(() => {
-                this.toast.info('Account updated successfully.');
-            });
+            const model = this.get('model');
+            // IF and ONLY if email address field is dirty, also update sendgrid email suppressions.
+            const isEmailDirty = !!model.changedAttributes().email;
+
+            if (!isEmailDirty) {
+                this._updateAccount();
+            } else {
+                // Get suppressions (old), then update account, then set suppressions for the new email address
+                // If the first or third promises fail, make sure a toast error is shown correctly, b/c user will need
+                //   to reset manually.
+                let suppressions;
+                model.getSuppressions()
+                    .then(oldEmailSettings => suppressions = oldEmailSettings)
+                    .then(() => this._updateAccount())
+                    .then(() => {
+                        const suppressionsHash = {};
+                        // Construct suppressions hash; see notes on setSuppressions
+                        (suppressions || [])
+                            .forEach(item => suppressionsHash[item.id] = !item.subscribed);
+
+                        return model.setSuppressions(suppressionsHash);
+                    })
+                    .catch(() => this.toast.error('Could not update notification preferences for your new email address. Please review the email preferences page.',
+                        'Error while updating account'));
+            }
         },
         cancel() {
             this.get('model').rollbackAttributes();

--- a/app/models/account.js
+++ b/app/models/account.js
@@ -61,6 +61,7 @@ export default Account.extend({
         });
     },
     setSuppressions(suppressionsHash) {
+        // Send subscriptions to the server: format {groupId: !subscribed} (except see optOut line below because yeah....)
         suppressionsHash.id = this.get('id');
         suppressionsHash[ASM_MAPPING.optOut.id] = !suppressionsHash[ASM_MAPPING.optOut.id];
         var url = this.get('suppressionsUrl');

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-bootstrap-datetimepicker": "1.0.4",
     "ember-cli": "2.8.0",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-babel": "^5.1.6",
+    "ember-cli-babel": "5.1.10",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-favicon": "0.0.4",
     "ember-cli-font-awesome": "1.4.2",


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-340

## Purpose
When a user changes their email, we should continue to honor their sendgrid opt-out preferences.

Previously, changing an email address caused a user to receive emails again, even if they had previously elected not to.


## Summary of changes
- When a user changes their email address, tell sendgrid to apply their previous email opt-out settings to the new address. Previously, changing an email address caused a user to be opted back in to every email. Users do not like this.

## Testing notes
Lookit account settings ("account information") page: `<lookit>/account`
Email preferences page: `<lookit>/account/email`

1. [x]  Visit your email preferences page. Click the first and fourth checkboxes. (so that you are receiving some emails, and unsubscribed from others, in a way that you will remember later)
2. [x] Go to the account settings page. Change just your "contact name" (but not your email address) and click "save". This should happen fairly quickly. You will see a success message, and the new name will still be there when you *refresh the page*.
    - [x] Confirm that your email preferences are not changed by the act of changing your human contact name.
3. [x] Go back to the account settings page. Now, change your email address to something you have never used before. Click save.
    - [x] You will see the same success message as in step 2, but it should take slightly longer than before to show up. (this is normal)
    - [x]  *Refresh the page in the browser* and confirm that the name and email address still show correctly as having changed. Go to your email preferences page. Confirm that even after changing your email address, the correct email preferences are applied.
- [ ] If you have access to Sendgrid, verify that the new email address shows up in suppression groups as appropriate. (I do not have access to the sendgrid account used on staging, but the page does reflect info sent back by the server. We can verify at this level of exactness on prod.)

If changes do not appear to propagate correctly, make sure to refresh the page. There is a tiny edge case bug where old settings could linger, but this PR makes it much less likely.