### PR TITLE
Fix issue with child birthdays on demographics page

### DIFF
--- a/app/controllers/my/demographics.js
+++ b/app/controllers/my/demographics.js
@@ -430,24 +430,7 @@ export default Ember.Controller.extend({
         }
         this.get('model.demographicsChildBirthdays').setObjects(birthdays);
     }),
-    childBirthdays: Ember.computed('model.demographicsChildBirthdays.[]', {
-        get: function() {
-            var ret = Ember.Object.create();
-            this.get('model.demographicsChildBirthdays').toArray().forEach(function(bd, i) {
-                ret.set(i.toString(), bd);
-            });
-            return ret;
-        },
-        set: function(_, birthdays) {
-            var ret = [];
-            Object.keys(birthdays).forEach(function(key) {
-                ret[parseInt(key)] = birthdays[key];
-            });
-            this.get('model.demographicsChildBirthdays').setObjects(ret);
-            this.propertyDidChange('childBirthdays');
-            return this.get('childBirthdays');
-        }
-    }),
+
     actions: {
         selectRaceIdentification: function(item) {
             var selectedRaceIdentification = this.get('selectedRaceIdentification') || [];
@@ -466,9 +449,7 @@ export default Ember.Controller.extend({
             });
         },
         setChildBirthday(index, birthday) {
-            var childBirthdays = this.get('childBirthdays');
-            childBirthdays.set(index.toString(), birthday);
-            this.set('childBirthdays', childBirthdays);
+            this.set(`model.demographicsChildBirthdays.${index}`, birthday);
         }
     }
 });

--- a/app/models/account.js
+++ b/app/models/account.js
@@ -14,7 +14,7 @@ export default Account.extend({
     mustResetPassword: DS.attr('boolean'),
 
     demographicsNumberOfChildren: DS.attr('string'),
-    demographicsChildBirthdays: DS.attr('dateList'),
+    demographicsChildBirthdays: DS.attr('dateList', {defaultValue: () => []}),
     demographicsLanguagesSpokenAtHome: DS.attr('string'),
     demographicsNumberOfGuardians: DS.attr('string'),
     demographicsNumberOfGuardiansExplanation: DS.attr('string'),

--- a/app/templates/my/demographics.hbs
+++ b/app/templates/my/demographics.hbs
@@ -1,183 +1,204 @@
 <div>
-  <div>
-    <p>One reason we are developing Internet-based experiments is to represent a more
-    diverse group of families in our research. Your answers to these questions will help
-    us understand what audience we reach, as well as how factors like speaking multiple languages or
-    having older siblings affect children's learning.</p>
+    <div>
+        <p>One reason we are developing Internet-based experiments is to represent a more
+            diverse group of families in our research. Your answers to these questions will help
+            us understand what audience we reach, as well as how factors like speaking multiple languages or
+            having older siblings affect children's learning.</p>
 
-    <p>Even if you allow your study videos to be published for scientific or publicity purposes, your demographic information is never published in conjunction with your video.</p>
+        <p>Even if you allow your study videos to be published for scientific or publicity purposes, your demographic
+            information is never published in conjunction with your video.</p>
 
-    <br>
-    {{#bs-form}}
-
-      {{#bs-form-group}}
-      <label>What country do you live in?</label>
-      <select onchange={{action (mut model.demographicsCountry) value="target.value"}} class="form-control">
-        <option value="" disabled selected hidden>Please choose...</option>
-        <option value="US" selected={{eq model.demographicsCountry "US"}}>United States</option>
-            <option disabled>─────────────────────</option>
-
-          {{#each countryOptions as |countryOption|}}
-            <option value={{countryOption.code}} selected={{eq model.demographicsCountry countryOption.code}}>{{countryOption.country}}</option>
-          {{/each}}
-      </select>
-      {{/bs-form-group}}
-
-
-      {{#if (eq model.demographicsCountry "US") }}
-      {{#bs-form-group}}
-      <label>What state do you live in?</label>
-      <select disabled={{not-eq model.demographicsCountry "US"}} onchange={{action (mut model.demographicsState) value="target.value"}} class="form-control">
-        <option value="" disabled selected hidden>Please choose...</option>
-          {{#each stateOptions as |stateOption|}}
-            <option value={{stateOption.code}} selected={{eq model.demographicsState stateOption.code}}>{{stateOption.state}}</option>
-          {{/each}}
-      </select>
-      {{/bs-form-group}}
-      {{/if}}
-
-      {{#bs-form-group}}
-          <label>How would you describe the area where you live?</label>
-          <select onchange={{action (mut model.demographicsDensity) value="target.value"}} class="form-control">
-            <option value="" disabled selected hidden>Please choose...</option>
-            {{#each densityOptions as |densityOption|}}
-              <option value={{densityOption}} selected={{eq model.demographicsDensity densityOption}}>{{densityOption}}</option>
-            {{/each}}
-          </select>
-      {{/bs-form-group}}
-
-      {{#bs-form-group}}
-        <label>What language(s) does your family speak at home?</label>
-        {{bs-input type="text" value=model.demographicsLanguagesSpokenAtHome}}
-      {{/bs-form-group}}
-      {{#bs-form-group}}
-        <label>How many children do you have?</label>
-        <select onchange={{action (mut model.demographicsNumberOfChildren) value="target.value"}}
-          class="form-control">
-          <option value="" disabled selected hidden>Please choose...</option>
-          {{#each childrenCounts as |childrenCount|}}
-            <option value={{childrenCount}} selected={{eq model.demographicsNumberOfChildren childrenCount}}>{{childrenCount}}</option>
-          {{/each}}
-        </select>
-        {{#if (eq model.demographicsNumberOfChildren 'More than 10')}}
         <br>
-        <div class="form-inline">
-          <label>I have {{bs-input class="form-control" type="text" value=nNumberOfChildren}} children</label>
-        </div>
-        {{/if}}
-      {{/bs-form-group}}
-      {{#if (not (eq numberOfChildren 0))}}
-      {{#bs-form-group}}
-        <label>For each child, please enter his or her birthdate below:</label>
-        {{#each-in childBirthdays as |index bd|}}
-        <div class="form-inline">
-          <div class="row">
-            <div class="col-xs-1">
-              <label>{{minus index -1}}.</Label>
-            </div>
-            <div class="col-xs-11">
-              <div class="input-group">
-                {{pikaday-input value=(unbound bd) onPikadaySelect=(action 'setChildBirthday' index) format="MM/DD/YYYY" yearRange="1990,currentYear" maxDate=today class="form-control"}}
-                {{#if bd}}
-                    <span class="input-group-addon">
+        {{#bs-form}}
+
+            {{#bs-form-group}}
+                <label>What country do you live in?</label>
+                <select onchange={{action (mut model.demographicsCountry) value="target.value"}} class="form-control">
+                    <option value="" disabled selected hidden>Please choose...</option>
+                    <option value="US" selected={{eq model.demographicsCountry "US"}}>United States</option>
+                    <option disabled>─────────────────────</option>
+
+                    {{#each countryOptions as |countryOption|}}
+                        <option value={{countryOption.code}} selected={{eq model.demographicsCountry
+                                                                           countryOption.code}}>{{countryOption.country}}</option>
+                    {{/each}}
+                </select>
+            {{/bs-form-group}}
+
+
+            {{#if (eq model.demographicsCountry "US") }}
+                {{#bs-form-group}}
+                    <label>What state do you live in?</label>
+                    <select disabled={{not-eq model.demographicsCountry "US"}} onchange={{action
+                        (mut model.demographicsState) value="target.value"}} class="form-control">
+                        <option value="" disabled selected hidden>Please choose...</option>
+                        {{#each stateOptions as |stateOption|}}
+                            <option value={{stateOption.code}} selected={{eq model.demographicsState
+                                                                             stateOption.code}}>{{stateOption.state}}</option>
+                        {{/each}}
+                    </select>
+                {{/bs-form-group}}
+            {{/if}}
+
+            {{#bs-form-group}}
+                <label>How would you describe the area where you live?</label>
+                <select onchange={{action (mut model.demographicsDensity) value="target.value"}} class="form-control">
+                    <option value="" disabled selected hidden>Please choose...</option>
+                    {{#each densityOptions as |densityOption|}}
+                        <option value={{densityOption}} selected={{eq model.demographicsDensity
+                                                                      densityOption}}>{{densityOption}}</option>
+                    {{/each}}
+                </select>
+            {{/bs-form-group}}
+
+            {{#bs-form-group}}
+                <label>What language(s) does your family speak at home?</label>
+                {{bs-input type="text" value=model.demographicsLanguagesSpokenAtHome}}
+            {{/bs-form-group}}
+            {{#bs-form-group}}
+                <label>How many children do you have?</label>
+                <select onchange={{action (mut model.demographicsNumberOfChildren) value="target.value"}}
+                            class="form-control">
+                    <option value="" disabled selected hidden>Please choose...</option>
+                    {{#each childrenCounts as |childrenCount|}}
+                        <option value={{childrenCount}} selected={{eq model.demographicsNumberOfChildren
+                                                                      childrenCount}}>{{childrenCount}}</option>
+                    {{/each}}
+                </select>
+                {{#if (eq model.demographicsNumberOfChildren 'More than 10')}}
+                    <br>
+                    <div class="form-inline">
+                        <label>I have {{bs-input class="form-control" type="text" value=nNumberOfChildren}}
+                            children</label>
+                    </div>
+                {{/if}}
+            {{/bs-form-group}}
+            {{#if (not (eq numberOfChildren 0))}}
+                {{#bs-form-group}}
+                    <label>For each child, please enter his or her birthdate below:</label>
+                    {{#each-in childBirthdays as |index bd|}}
+                        <div class="form-inline">
+                            <div class="row">
+                                <div class="col-xs-1">
+                                    <label>{{minus index -1}}.</Label>
+                                </div>
+                                <div class="col-xs-11">
+                                    <div class="input-group">
+                                        {{pikaday-input value=(unbound bd)
+                                                        onPikadaySelect=(action 'setChildBirthday' index)
+                                                        format="MM/DD/YYYY" yearRange="1990,currentYear" maxDate=today
+                                                        class="form-control"}}
+                                        {{#if bd}}
+                                            <span class="input-group-addon">
                         {{age bd hideSuffix=true}} old
                     </span>
+                                        {{/if}}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {{/each-in}}
+                {{/bs-form-group}}
+            {{/if}}
+            {{#bs-form-group}}
+                <label>How many parents/guardians do your children live with?</label>
+                <br/>If the answer varies due to shared custody arrangements or travel,
+                please enter the number of parents/guardians your children are usually
+                living with or explain below.
+                <select onchange={{action (mut model.demographicsNumberOfGuardians) value="target.value"}}
+                            class="form-control">
+                    <option value="" disabled selected hidden>Please choose...</option>
+                    {{#each guardianOptions as |guardianOption|}}
+                        <option value={{guardianOption}} selected={{eq model.demographicsNumberOfGuardians
+                                                                       guardianOption}}>{{guardianOption}}</option>
+                    {{/each}}
+                </select>
+            {{/bs-form-group}}
+            {{#bs-form-group}}
+                {{#if (eq model.demographicsNumberOfGuardians "varies")}}
+                    <label>If you answered "varies" above, please explain:</label>
+                    {{bs-input type="text" value=model.demographicsNumberOfGuardiansExplanation}}
                 {{/if}}
-              </div>
-            </div>
-          </div>
-        </div>
-        {{/each-in}}
-      {{/bs-form-group}}
-      {{/if}}
-      {{#bs-form-group}}
-        <label>How many parents/guardians do your children live with?</label>
-        <br />If the answer varies due to shared custody arrangements or travel,
-        please enter the number of parents/guardians your children are usually
-        living with or explain below.
-        <select onchange={{action (mut model.demographicsNumberOfGuardians) value="target.value"}}
-          class="form-control">
-          <option value="" disabled selected hidden>Please choose...</option>
-          {{#each guardianOptions as |guardianOption|}}
-            <option value={{guardianOption}} selected={{eq model.demographicsNumberOfGuardians guardianOption}}>{{guardianOption}}</option>
-          {{/each}}
-        </select>
-      {{/bs-form-group}}
-      {{#bs-form-group}}
-          {{#if (eq model.demographicsNumberOfGuardians "varies")}}
-              <label>If you answered "varies" above, please explain:</label>
-                  {{bs-input type="text" value=model.demographicsNumberOfGuardiansExplanation}}
-          {{/if}}
-      {{/bs-form-group}}
+            {{/bs-form-group}}
 
-      {{#bs-form-group}}
-        <label>What category(ies) does your family identify as?</label>
-        <div onchange={{action 'selectRaceIdentification' value='target'}} id="raceIdentification">
-          {{#each raceCategories as |raceCategory|}}
-            <label class="checkbox">
-              <input type="checkbox" value={{raceCategory}} checked={{include model.demographicsRaceIdentification raceCategory}}> {{raceCategory}}
-            </label>
-          {{/each}}
-        </div>
-      {{/bs-form-group}}
-      {{#bs-form-group}}
-        <label>What is your age?</label>
-        <select onchange={{action (mut model.demographicsAge) value="target.value"}} class="form-control" >
-          <option value="" disabled selected hidden>Please choose...</option>
-          {{#each ageChoices as |ageChoice|}}
-            <option value={{ageChoice}} selected={{eq model.demographicsAge ageChoice}}>{{ageChoice}}</option>
-          {{/each}}
-        </select>
-      {{/bs-form-group}}
-      {{#bs-form-group}}
-        <label>What is your gender?</label>
-        <select onchange={{action (mut model.demographicsGender) value="target.value"}} class="form-control" >
-          <option value="" disabled selected hidden>Please choose...</option>
-          {{#each genderOptions as |genderOption|}}
-            <option value={{genderOption}} selected={{eq model.demographicsGender genderOption}}>{{genderOption}}</option>
-          {{/each}}
-        </select>
-      {{/bs-form-group}}
-      {{#bs-form-group}}
-        <label>What is the highest level of education you've completed?</label>
-        <select onchange={{action (mut model.demographicsEducationLevel) value="target.value"}} class="form-control" >
-          <option value="" disabled selected hidden>Please choose...</option>
-          {{#each educationOptions as |educationOption|}}
-            <option value={{educationOption}} selected={{eq model.demographicsEducationLevel educationOption}}>{{educationOption}}</option>
-          {{/each}}
-        </select>
-      {{/bs-form-group}}
-      {{#bs-form-group}}
-        <label>What is the highest level of education your spouse has completed?</label>
-        <select onchange={{action (mut model.demographicsSpouseEducationLevel) value="target.value"}} class="form-control" >
-          <option value="" disabled selected hidden>Please choose...</option>
-          {{#each spouseEducationOptions as |spouseEducationOption|}}
-            <option value={{spouseEducationOption}} selected={{eq model.demographicsSpouseEducationLevel spouseEducationOption}}>{{spouseEducationOption}}</option>
-          {{/each}}
-        </select>
-      {{/bs-form-group}}
-      {{#bs-form-group}}
-        <label>What is your approximate family yearly income (in US dollars)?</label>
-        <select onchange={{action (mut model.demographicsAnnualIncome) value="target.value"}} class="form-control" >
-          <option value="" disabled selected hidden>Please choose...</option>
-          {{#each annualIncomeOptions as |annualIncomeOption|}}
-           <option value={{annualIncomeOption}} selected={{eq model.demographicsAnnualIncome annualIncomeOption}}>{{annualIncomeOption}}</option>
-          {{/each}}
-        </select>
-      {{/bs-form-group}}
-      {{#bs-form-group}}
-        <label>About how many children's books are there in your home?</label>
-        {{bs-input type="number" value=model.demographicsNumberOfBooks min=0}}
-	{{#if (not (gte model.demographicsNumberOfBooks 0)) }}
-	  <span class="text-danger">Please enter a value greater than or equal to zero</span>
-	{{/if}}
-      {{/bs-form-group}}
-      {{#bs-form-group}}
-        <label>Anything else you'd like us to know?</label>
-        {{bs-textarea value=model.demographicsAdditionalComments}}
-      {{/bs-form-group}}
-      <br />
-      {{#bs-button type="success" action="saveDemographicsPreferences" disabled=(not isValid) class="pull-right"}}Save{{/bs-button}}
-    {{/bs-form}}
-  </div>
+            {{#bs-form-group}}
+                <label>What category(ies) does your family identify as?</label>
+                <div onchange={{action 'selectRaceIdentification' value='target'}} id="raceIdentification">
+                    {{#each raceCategories as |raceCategory|}}
+                        <label class="checkbox">
+                            <input type="checkbox" value={{raceCategory}} checked={{include
+                                model.demographicsRaceIdentification raceCategory}}> {{raceCategory}}
+                        </label>
+                    {{/each}}
+                </div>
+            {{/bs-form-group}}
+            {{#bs-form-group}}
+                <label>What is your age?</label>
+                <select onchange={{action (mut model.demographicsAge) value="target.value"}} class="form-control">
+                    <option value="" disabled selected hidden>Please choose...</option>
+                    {{#each ageChoices as |ageChoice|}}
+                        <option value={{ageChoice}} selected={{eq model.demographicsAge
+                                                                  ageChoice}}>{{ageChoice}}</option>
+                    {{/each}}
+                </select>
+            {{/bs-form-group}}
+            {{#bs-form-group}}
+                <label>What is your gender?</label>
+                <select onchange={{action (mut model.demographicsGender) value="target.value"}} class="form-control">
+                    <option value="" disabled selected hidden>Please choose...</option>
+                    {{#each genderOptions as |genderOption|}}
+                        <option value={{genderOption}} selected={{eq model.demographicsGender
+                                                                     genderOption}}>{{genderOption}}</option>
+                    {{/each}}
+                </select>
+            {{/bs-form-group}}
+            {{#bs-form-group}}
+                <label>What is the highest level of education you've completed?</label>
+                <select onchange={{action (mut model.demographicsEducationLevel)
+                                          value="target.value"}} class="form-control">
+                    <option value="" disabled selected hidden>Please choose...</option>
+                    {{#each educationOptions as |educationOption|}}
+                        <option value={{educationOption}} selected={{eq model.demographicsEducationLevel
+                                                                        educationOption}}>{{educationOption}}</option>
+                    {{/each}}
+                </select>
+            {{/bs-form-group}}
+            {{#bs-form-group}}
+                <label>What is the highest level of education your spouse has completed?</label>
+                <select onchange={{action (mut model.demographicsSpouseEducationLevel)
+                                          value="target.value"}} class="form-control">
+                    <option value="" disabled selected hidden>Please choose...</option>
+                    {{#each spouseEducationOptions as |spouseEducationOption|}}
+                        <option value={{spouseEducationOption}} selected={{eq model.demographicsSpouseEducationLevel
+                                                                              spouseEducationOption}}>{{spouseEducationOption}}</option>
+                    {{/each}}
+                </select>
+            {{/bs-form-group}}
+            {{#bs-form-group}}
+                <label>What is your approximate family yearly income (in US dollars)?</label>
+                <select
+                    onchange={{action (mut model.demographicsAnnualIncome) value="target.value"}} class="form-control">
+                    <option value="" disabled selected hidden>Please choose...</option>
+                    {{#each annualIncomeOptions as |annualIncomeOption|}}
+                        <option value={{annualIncomeOption}} selected={{eq model.demographicsAnnualIncome
+                                                                           annualIncomeOption}}>{{annualIncomeOption}}</option>
+                    {{/each}}
+                </select>
+            {{/bs-form-group}}
+            {{#bs-form-group}}
+                <label>About how many children's books are there in your home?</label>
+                {{bs-input type="number" value=model.demographicsNumberOfBooks min=0}}
+                {{#if (not (gte model.demographicsNumberOfBooks 0)) }}
+                    <span class="text-danger">Please enter a value greater than or equal to zero</span>
+                {{/if}}
+            {{/bs-form-group}}
+            {{#bs-form-group}}
+                <label>Anything else you'd like us to know?</label>
+                {{bs-textarea value=model.demographicsAdditionalComments}}
+            {{/bs-form-group}}
+            <br/>
+            {{#bs-button type="success" action="saveDemographicsPreferences" disabled=(not isValid) class="pull-right"}}
+                Save{{/bs-button}}
+        {{/bs-form}}
+    </div>
 </div>

--- a/app/templates/my/demographics.hbs
+++ b/app/templates/my/demographics.hbs
@@ -76,7 +76,7 @@
             {{#if (not (eq numberOfChildren 0))}}
                 {{#bs-form-group}}
                     <label>For each child, please enter his or her birthdate below:</label>
-                    {{#each-in childBirthdays as |index bd|}}
+                    {{#each model.demographicsChildBirthdays as |bd index|}}
                         <div class="form-inline">
                             <div class="row">
                                 <div class="col-xs-1">
@@ -90,14 +90,14 @@
                                                         class="form-control"}}
                                         {{#if bd}}
                                             <span class="input-group-addon">
-                        {{age bd hideSuffix=true}} old
-                    </span>
+                                                {{age bd hideSuffix=true}} old
+                                            </span>
                                         {{/if}}
                                     </div>
                                 </div>
                             </div>
                         </div>
-                    {{/each-in}}
+                    {{/each}}
                 {{/bs-form-group}}
             {{/if}}
             {{#bs-form-group}}


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-360

## Purpose
Fix an issue reported by QA (see linked ticket):

> On the Demographic Survey form on Lookit, beneath "For each child, please enter his or her birthdate below:" there is no input field to enter the information. After filling out other parts of the form and clicking "Save," the input fields suddenly appear. This bug only seems to be occurring for newly-created users. 

## Summary of changes
- Add a default value for `<account>.demographicsChildBirthdays`
- Clean up overcomplicated code

## Testing notes
After saving, also refresh the page to see if the data is still there.

1. Verify that reported issue is resolved as written

Also:
- [x] Verify that for an existing account, changing number of children (or birthdays) registers changes after saving.
- [x] Verify that for a new account, can select a different number of children and see new items immediately (before saving)
  - [x] For a larger number of children than before
  - [x] For a smaller number of children than before
- [x] Verify that for a new account, fields behave as expected after saving
- [x] Confirm that birthdays saved are correct and complete
- [x] Verify that the child birthdays are displayed as a numbered list, starting at 1
- [x] If you select that you have no children, the birthdays section should be empty/invisible
