### PR TITLE
Display eligibility string but not additionally age range in study de…

### DIFF
--- a/app/templates/studies/detail.hbs
+++ b/app/templates/studies/detail.hbs
@@ -27,10 +27,6 @@
               {{model.eligibilityString}}
             </p>
             <p>
-              <strong>Age range:</strong>
-              {{model.ageRange}}
-            </p>
-            <p>
               <strong>Duration: </strong>
               {{model.duration}}
             </p>


### PR DESCRIPTION
…tail view, to avoid redundant (or conflicting, when age range is slightly broader) information

Refs: https://openscience.atlassian.net/browse/LEI-


