### PR TITLE
show different warnings based on whether child is older/younger than …

### DIFF
--- a/app/controllers/studies/detail.js
+++ b/app/controllers/studies/detail.js
@@ -22,6 +22,15 @@ export default Ember.Controller.extend({
         return experiment.isEligible(child);
     }),
 
+    isAgeOldEnough: Ember.computed('selectedChild', function () {
+        let child = this.get('selectedChild');
+        if (!child) {
+            return true;
+        }
+        let experiment = this.get('model');
+        return experiment.isOldEnough(child);
+    }),
+
     route: Ember.computed('model', function () {
         return `${Ember.getOwner(this).lookup('router:main').get('currentPath')}:${this.get('model.id')}`;
     }),

--- a/app/templates/studies/detail.hbs
+++ b/app/templates/studies/detail.hbs
@@ -58,9 +58,9 @@
               </div>
 	      {{#if (and selectedChild (not isAgeEligible))}}
 	        {{#if (and selectedChild (not isAgeOldEnough))}}
-	            <p class="text-warning">Your child is still below than the recommended age range for this study. If you can wait until he or she is old enough, we'll be able to use the collected data in our research! </p>
+	            <p class="text-warning">Your child is still younger than the recommended age range for this study. If you can wait until he or she is old enough, we'll be able to use the collected data in our research! </p>
 	        {{else}}
-	            <p class="text-warning">Your child is above than the recommended age range for this study. You're welcome to try the study anyway, but we won't be able to use the collected data in our research.</p>
+	            <p class="text-warning">Your child is older than the recommended age range for this study. You're welcome to try the study anyway, but we won't be able to use the collected data in our research.</p>
 	        {{/if}}
 	      {{/if}}
               <button disabled={{if (not selectedChildId) true false}} class="btn btn-lg btn-primary {{if (not selectedChildId) 'disabled'}}" onclick={{action 'pickChild'}}>Participate now!</button>

--- a/app/templates/studies/detail.hbs
+++ b/app/templates/studies/detail.hbs
@@ -57,7 +57,11 @@
                 </select>
               </div>
 	      {{#if (and selectedChild (not isAgeEligible))}}
-		  <p class="text-warning">Your child is outside of the recommended age range for this study. You're welcome to try the study anyway, but we won't be able to use the collected data in our research.</p>
+	        {{#if (and selectedChild (not isAgeOldEnough))}}
+	            <p class="text-warning">Your child is still below than the recommended age range for this study. If you can wait until he or she is old enough, we'll be able to use the collected data in our research! </p>
+	        {{else}}
+	            <p class="text-warning">Your child is above than the recommended age range for this study. You're welcome to try the study anyway, but we won't be able to use the collected data in our research.</p>
+	        {{/if}}
 	      {{/if}}
               <button disabled={{if (not selectedChildId) true false}} class="btn btn-lg btn-primary {{if (not selectedChildId) 'disabled'}}" onclick={{action 'pickChild'}}>Participate now!</button>
             {{/if}}


### PR DESCRIPTION
…age range

## Purpose
Ask parents to wait and participate later if their child is under the age range, rather than just showing standard out-of-age-range warning

Should be applied after https://github.com/CenterForOpenScience/exp-addons/pull/231 so we have access to the appropriate function of the experiment model
